### PR TITLE
Add missing include for <stdint.h>

### DIFF
--- a/QuoteGeneration/common/inc/internal/elfheader/elf_common.h
+++ b/QuoteGeneration/common/inc/internal/elfheader/elf_common.h
@@ -30,6 +30,8 @@
 #ifndef _SYS_ELF_COMMON_H_
 #define	_SYS_ELF_COMMON_H_ 1
 
+#include <stdint.h>
+
 typedef uint32_t u_int32_t;
 typedef uint32_t Elf_Symndx;
 

--- a/QuoteGeneration/common/inc/internal/elfheader/elfstructs.h
+++ b/QuoteGeneration/common/inc/internal/elfheader/elfstructs.h
@@ -26,6 +26,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdint.h>
+
 typedef uint8_t		Elf_Byte;
 
 typedef uint32_t	Elf32_Addr;	/* Unsigned program address */


### PR DESCRIPTION
This is necessary so that these headers can be compiled independently of their uses. Currently, the project's Makefiles rely on the inclusion of stdint.h in locations where elf_common.h and elfstructs.h are used, but this pattern will not necessary work in other build systems.