### PR TITLE
sgx_util: flags redefined as crt_flags in >= v5.2

### DIFF
--- a/driver/linux/sgx_util.c
+++ b/driver/linux/sgx_util.c
@@ -359,7 +359,12 @@ int sgx_get_key_hash(struct crypto_shash *tfm, const void *modulus, void *hash)
 	SHASH_DESC_ON_STACK(shash, tfm);
 
 	shash->tfm = tfm;
-	shash->flags = CRYPTO_TFM_REQ_MAY_SLEEP;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,2,0))
+        shash->tfm->base.crt_flags = CRYPTO_TFM_REQ_MAY_SLEEP;
+#else
+        shash->flags = CRYPTO_TFM_REQ_MAY_SLEEP;
+#endif
 
 	return crypto_shash_digest(shash, modulus, SGX_MODULUS_SIZE, hash);
 }


### PR DESCRIPTION
Assign CRYPTO_TFM_REQ_MAY_SLEEP to crt_flags defined in struct
crypto_tfm, instead of flags in struct shash_desc since
struct shash_desc u32 flags have been redefined in struct crypto_tfm
starting from kernel v5.2:
https://elixir.bootlin.com/linux/v5.2.2/source/include/linux/crypto.h#L751
https://elixir.bootlin.com/linux/v5.1.19/source/include/crypto/hash.h#L147

Signed-off-by: Iyer, Naveen <naveen.iyer@intel.com>