### PR TITLE
Add sgx_qe_set_enclave_dirpath

### DIFF
--- a/QuoteGeneration/pce_wrapper/inc/sgx_pce.h
+++ b/QuoteGeneration/pce_wrapper/inc/sgx_pce.h
@@ -41,6 +41,10 @@
 #include "sgx_key.h"
 #include "sgx_report.h"
 
+#ifdef _MSC_VER
+#include <tchar.h>
+#endif
+
 #define SGX_PCE_MK_ERROR(x)          (0x0000F000|(x))
 typedef enum _sgx_pce_error_t
 {
@@ -90,6 +94,14 @@ extern "C" {
 
 sgx_pce_error_t sgx_set_pce_enclave_load_policy(
                               sgx_ql_request_policy_t policy);
+
+/** Set the directory in which the PCE binary is located. */
+sgx_pce_error_t sgx_set_pce_enclave_dirpath(
+#if defined(_MSC_VER)
+                              const TCHAR *dirpath);
+#else
+                              const char *dirpath);
+#endif
 
 sgx_pce_error_t sgx_pce_get_target(
                               sgx_target_info_t *p_pce_target,

--- a/QuoteGeneration/pce_wrapper/linux/pce_parser.cpp
+++ b/QuoteGeneration/pce_wrapper/linux/pce_parser.cpp
@@ -144,6 +144,7 @@ bool pce_get_metadata(const char* enclave_file, metadata_t *metadata)
 
 #define PCE_ENCLAVE_NAME "libsgx_pce.signed.so"
 bool get_pce_path(
+    const char *p_dirpath,
     char *p_file_path,
     size_t buf_size)
 {
@@ -151,10 +152,19 @@ bool get_pce_path(
         return false;
 
     Dl_info dl_info;
-    if(0 != dladdr(__builtin_return_address(0), &dl_info) &&
+    if (p_dirpath != NULL)
+    {
+        if(strnlen(p_dirpath,buf_size)==buf_size)
+        {
+            SE_TRACE(SE_TRACE_ERROR, "Input dirpath is too long\n");
+            return false;
+        }
+        (void)strncpy(p_file_path,p_dirpath,buf_size);
+    }
+    else if(0 != dladdr(__builtin_return_address(0), &dl_info) &&
         NULL != dl_info.dli_fname)
     {
-        if(strnlen(dl_info.dli_fname,buf_size)>=buf_size)
+        if(strnlen(dl_info.dli_fname,buf_size)==buf_size)
             return false;
         (void)strncpy(p_file_path,dl_info.dli_fname,buf_size);
     }

--- a/QuoteGeneration/pce_wrapper/win/pce_parser.cpp
+++ b/QuoteGeneration/pce_wrapper/win/pce_parser.cpp
@@ -121,6 +121,7 @@ bool pce_get_metadata(const TCHAR* enclave_file, metadata_t *metadata)
 #define PCE_ENCLAVE_NAME _T("pce.signed.dll")
 
 bool get_pce_path(
+    const TCHAR *p_dirpath,
     TCHAR *p_file_path,
     size_t buf_size)
 {
@@ -128,13 +129,25 @@ bool get_pce_path(
         return false;
 
     HMODULE hModule;
-    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, _T(__FUNCTION__), &hModule))
-        return false;
-    DWORD path_length = GetModuleFileName(hModule, p_file_path, static_cast<DWORD>(buf_size));
-    if (path_length == 0)
-        return false;
-    if (path_length == buf_size)
-        return false;
+    if (p_dirpath != NULL)
+    {
+        if(_tcsnlen(p_dirpath,buf_size)==buf_size)
+        {
+            SE_TRACE(SE_TRACE_ERROR, "Input dirpath is too long\n");
+            return false;
+        }
+        (void)_tcsncpy(p_file_path,p_dirpath,buf_size);
+    }
+    else
+    {
+        if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, _T(__FUNCTION__), &hModule))
+            return false;
+        DWORD path_length = GetModuleFileName(hModule, p_file_path, static_cast<DWORD>(buf_size));
+        if (path_length == 0)
+            return false;
+        if (path_length == buf_size)
+            return false;
+    }
 
     TCHAR *p_last_slash = _tcsrchr(p_file_path, _T('\\'));
     if (p_last_slash != NULL)

--- a/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_ecdsa_quote.h
+++ b/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_ecdsa_quote.h
@@ -41,12 +41,22 @@
 
 #include "sgx_ql_quote.h"
 
+#ifdef _MSC_VER
+#include <tchar.h>
+#endif
+
 /**
     Class definition of the reference ECDSA-P256 quoting code which implements the quoting interface, IQuote.
 */
 class ECDSA256Quote :public IQuote {
 public:
     virtual quote3_error_t set_enclave_load_policy(sgx_ql_request_policy_t policy);
+
+#ifdef _MSC_VER
+    virtual quote3_error_t set_enclave_dirpath(const TCHAR *dirpath);
+#else
+    virtual quote3_error_t set_enclave_dirpath(const char *dirpath);
+#endif
 
     virtual quote3_error_t init_quote(sgx_ql_att_key_id_t* p_att_key_id,
                                       sgx_ql_cert_key_type_t certification_key_type,
@@ -67,6 +77,12 @@ public:
 
 private:
     quote3_error_t ecdsa_set_enclave_load_policy(sgx_ql_request_policy_t policy);
+
+#ifdef _MSC_VER
+    quote3_error_t ecdsa_set_enclave_dirpath(const TCHAR *dirpath);
+#else
+    quote3_error_t ecdsa_set_enclave_dirpath(const char *dirpath);
+#endif
 
     quote3_error_t ecdsa_init_quote(sgx_ql_cert_key_type_t certification_key_type,
                                     sgx_target_info_t *p_target_info,

--- a/QuoteGeneration/quote_wrapper/ql/inc/sgx_dcap_ql_wrapper.h
+++ b/QuoteGeneration/quote_wrapper/ql/inc/sgx_dcap_ql_wrapper.h
@@ -42,11 +42,21 @@
 #include "sgx_pce.h"
 #include "sgx_ql_lib_common.h"
 
+#if defined(_MSC_VER)
+#include <tchar.h>
+#endif
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
 quote3_error_t sgx_qe_set_enclave_load_policy(sgx_ql_request_policy_t policy);
+
+#if defined(_MSC_VER)
+quote3_error_t sgx_qe_set_enclave_dirpath(const TCHAR *dirpath);
+#else
+quote3_error_t sgx_qe_set_enclave_dirpath(const char *dirpath);
+#endif
 
 quote3_error_t sgx_qe_get_target_info(sgx_target_info_t *p_qe_target_info);
 

--- a/QuoteGeneration/quote_wrapper/ql/sgx_dcap_ql_wrapper.cpp
+++ b/QuoteGeneration/quote_wrapper/ql/sgx_dcap_ql_wrapper.cpp
@@ -46,6 +46,10 @@
 #include "sgx_quote_3.h"
 #include "se_trace.h"
 
+#ifndef _MSC_VER
+typedef char TCHAR;
+#endif
+
 /** 
  * When the Quoting Library is linked to a process, it needs to know the proper enclave loading policy.  The library
  * may be linked with a long lived process, such as a service, where it can load the enclaves and leave them loaded 
@@ -72,6 +76,19 @@ extern "C" quote3_error_t sgx_qe_set_enclave_load_policy(sgx_ql_request_policy_t
     quote_ret = sgx_ql_set_enclave_load_policy(policy);
 
     return(quote_ret);
+}
+
+/**
+ * This API will explicitly set the directory where enclaves required for quoting are located. By default, enclaves
+ * are assumed to be located in the same directory as the application which is calling the ECDSA quoting APIs. This
+ * API will override that default, locating the quoting and provisioning enclaves in dirpath.
+ *
+ * @param dirpath The directory where the quoting and provisioning enclaves are. If NULL, any previously-set
+ * path is cleared.
+ */
+extern "C" quote3_error_t sgx_qe_set_enclave_dirpath(const TCHAR *dirpath)
+{
+    return(sgx_ql_set_enclave_dirpath(dirpath));
 }
 
 /**

--- a/QuoteGeneration/quote_wrapper/quote/inc/sgx_ql_core_wrapper.h
+++ b/QuoteGeneration/quote_wrapper/quote/inc/sgx_ql_core_wrapper.h
@@ -40,6 +40,10 @@
 #include "sgx_quote_3.h"
 #include "sgx_ql_quote.h"
 
+#if defined(_MSC_VER)
+#include <tchar.h>
+#endif
+
 #define SGX_QL_MAX_ATT_KEY_IDS 10
 
 #define SGX_QL_CERT_TYPE PPID_RSA3072_ENCRYPTED 
@@ -49,6 +53,12 @@ extern "C" {
 #endif
 
 quote3_error_t sgx_ql_set_enclave_load_policy(sgx_ql_request_policy_t policy);
+
+#if defined(_MSC_VER)
+quote3_error_t sgx_ql_set_enclave_dirpath(const TCHAR *dirpath);
+#else
+quote3_error_t sgx_ql_set_enclave_dirpath(const char *dirpath);
+#endif
 
 quote3_error_t sgx_ql_select_att_key_id(sgx_ql_att_key_id_list_t *p_att_key_id_list,
                                         sgx_ql_att_key_id_t **p_selected_key_id);

--- a/QuoteGeneration/quote_wrapper/quote/sgx_ql_core_wrapper.cpp
+++ b/QuoteGeneration/quote_wrapper/quote/sgx_ql_core_wrapper.cpp
@@ -42,8 +42,13 @@
 #include "user_types.h"
 #include "sgx_report.h"
 #include "sgx_ql_ecdsa_quote.h"
+#include "sgx_ql_lib_common.h"
 #include "sgx_ql_core_wrapper.h"
 #include "qe3.h"
+
+#ifndef _MSC_VER
+typedef char TCHAR;
+#endif
 
 #ifdef USE_DEBUG_MRSIGNER
 // This is the mrsigner for debug key
@@ -120,6 +125,31 @@ quote3_error_t sgx_ql_set_enclave_load_policy(sgx_ql_request_policy_t policy)
     }
 
     ret_val = ecdsa_quote.set_enclave_load_policy(policy);
+    if(SGX_QL_SUCCESS != ret_val) {
+        if((ret_val < SGX_QL_ERROR_MIN) ||
+           (ret_val > SGX_QL_ERROR_MAX))
+        {
+                ret_val = SGX_QL_ERROR_UNEXPECTED;
+        }
+    }
+
+    return(ret_val);
+}
+
+/**
+ * This API will explicitly set the directory where enclaves required for quoting are located. By default, enclaves
+ * are assumed to be located in the same directory as the application which is calling the ECDSA quoting APIs. This
+ * API will override that default, locating the quoting and provisionining enclaves in dirpath.
+ *
+ * @param dirpath The directory where the quoting and provisioning enclaves are. If NULL, any previously-set
+ * path is cleared.
+ */
+quote3_error_t sgx_ql_set_enclave_dirpath(const TCHAR *dirpath)
+{
+    quote3_error_t ret_val = SGX_QL_ERROR_UNEXPECTED;
+    ECDSA256Quote ecdsa_quote;
+
+    ret_val = ecdsa_quote.set_enclave_dirpath(dirpath);
     if(SGX_QL_SUCCESS != ret_val) {
         if((ret_val < SGX_QL_ERROR_MIN) ||
            (ret_val > SGX_QL_ERROR_MAX))


### PR DESCRIPTION
The new sgx_qe_set_enclave_dirpath function allows customization of the
location where Intel architectural enclaves are. Prior to this, all
Intel architectural enclaves were required to be in the same directory
as the process which loaded them.

Additionally, enclave-specific functions have been added for setting
the dirpath for PCE and QE separately.

Signed-off-by: Seth Moore <sethmo@google.com>