### PR TITLE
Fix incorrect key type constants

### DIFF
--- a/QuoteVerification/QVL/Src/AttestationLibrary/src/QuoteVerification/QuoteConstants.h
+++ b/QuoteVerification/QVL/Src/AttestationLibrary/src/QuoteVerification/QuoteConstants.h
@@ -38,8 +38,8 @@ namespace intel { namespace sgx { namespace qvl { namespace constants {
 
 const uint16_t QUOTE_VERSION = 3;
 
-const uint16_t ECDSA_256_WITH_P256_CURVE = 1;
-const uint16_t ECDSA_384_WITH_P384_CURVE = 2;
+const uint16_t ECDSA_256_WITH_P256_CURVE = 2;
+const uint16_t ECDSA_384_WITH_P384_CURVE = 3;
 constexpr size_t ECDSA_P256_SIGNATURE_BYTE_LEN = 64;
 constexpr size_t ENCLAVE_REPORT_BYTE_LEN = 384;
 


### PR DESCRIPTION
According to Intel_SGX_ECDSA_QuoteGenReference_DCAP_API_Linux_1.2.pdf:
the "Attestation Key Type" constants are:
  - 2 (ECDSA-256-with-P-256 curve)
  - 3 (ECDSA-384-with-P-384 curve) (Note: currently not supported)
  (Note: 0 and 1 are reserved, EPID is moved to
  version 3 quotes.)