### PR TITLE
Minor fixes for DCAP driver

### DIFF
--- a/driver/linux/Makefile
+++ b/driver/linux/Makefile
@@ -66,11 +66,20 @@ intel_sgx-y := \
 else
 
 KDIR := /lib/modules/$(shell uname -r)/build
+
+INKERNEL_SGX :=$(shell cat $(KDIR)/.config | grep "CONFIG_INTEL_SGX=y")
+ifneq ($(INKERNEL_SGX),)
+default:
+	$(error Can't install DCAP SGX driver with inkernel SGX support)
+
+else
+
 PWD  := $(shell pwd)
 
 default:
 	$(MAKE) -C $(KDIR) M=$(PWD) CFLAGS_MODULE="-I$(PWD) -I$(PWD)/include" modules
 
+endif
 endif
 
 clean:

--- a/driver/linux/README.md
+++ b/driver/linux/README.md
@@ -16,13 +16,13 @@ Documentation
 
 Build and Install the Intel(R) SGX Driver
 -----------------------------------------
-### Prerequisites         
-- Ensure that you have the following required operating systems:  
+### Prerequisites
+- Ensure that you have the following required operating systems:
   * Ubuntu* 16.04 LTS Desktop 64bits - minimal kernel 4.10
   * Ubuntu* 16.04 LTS Server 64bits - minimal kernel 4.10
   * Ubuntu* 18.04 LTS Desktop 64bits
   * Ubuntu* 18.04 LTS Server 64bits
-- Ensure that you have the following required hardware:  
+- Ensure that you have the following required hardware:
   * 8th Generation Intel(R) Core(TM) Processor or newer with **Flexible Launch Control** and **Intel(R) AES New Instructions** support*
   * Intel(R) Atom(TM) Processor with **Flexible Launch Control** and **Intel(R) AES New Instructions** support*
 - Configure the system with the **SGX hardware enabled** option.
@@ -35,69 +35,25 @@ Build and Install the Intel(R) SGX Driver
         ```
         $ sudo apt-get install linux-headers-$(uname -r)
         ```
-- OpenSSL is required for the Launch Enclave signing.
-   * To install OpenSSl:
- 		```
-        $ sudo apt-get install libssl-dev
-        ```
-  
+
 **Note:** Refer to the *"Intel® SGX Resource Enumeration Leaves"* section in the [Intel SGX Programming reference guide](https://software.intel.com/sites/default/files/managed/48/88/329298-002.pdf) to make sure your cpu has the SGX feature.
 
 
-### Build the Intel(R) SGX Driver 
-The driver build process is also building and integrating the Launch Enclave as part of the build process.
-As the Launch Enclave must be signed, the driver build process supports two methods of build:
-- Single step / debug:     
-  In this method the LE is built and signed as part of the driver build process, the private key may be provided to the build command or auto-generated during the build
-- Two steps / production:      
-  In this method the first step builds the Launch Enclave and generates the signing materials, which should be signed by some signing entity separately. In the second step the signature and the public key are used to continue the build and generate the driver.
-
-These build options are provided to support the above two build methods:
-- sign:     
-   Build option for the single step build process. It builds the Launch Enclave, signs it and integrate it into the driver. The private key may be provided to the build command by specifying ```SGX_LE_SIGNING_KEY_PATH=<path/to/private/key>``` (default: ./sgx_signing_key.pem), if the key does not exist it will be generated.
-- gendata:     
-   Build option for the first step in the two steps process. It builds the Launch Enclave and prepared the signing materials for it. The output of the build may be defined by specifying ```SGX_LE_SIGNING_MATERIAL=<path/to/signing/material>``` (default: ./signing_material.bin).
-- usesig:    
-   Build option for the second step in the two steps process. It gets the signature file and the public key, and uses them to integrate with the driver build. 
-   The signature file **must** be provided by specifying ```SIG_FILE=<path/to/signature>```.  
-   In addition the public key file may be specified by using ```SGX_LE_PUBLIC_KEY_PATH=<path/to/public/key>``` (default: ./sgx_public_key.pem).
-
-#### Build Intel(R) SGX Driver Using Single Step Process
-
-The following is an example for a single step make command:
+### Build the Intel(R) SGX Driver
+To build the Intel(R) SGX Driver use the following command line:
 ```
-$ make sign SGX_LE_SIGNING_KEY_PATH=~/my_private_key.pem 
+$ make
 ```
-**Note:** The **SGX_LE_SIGNING_KEY_PATH** is NOT a mandatory parameter. 
-
-#### Build Intel(R) SGX Driver Using Two Steps Process
-The following lines are an example for two steps make process:
-```
-$ make gendata SGX_LE_SIGNING_MATERIAL=~/signing_material.bin
-$ [sign the generated signing material]
-$ make usesig SIG_FILE=~/signature_file.bin SGX_LE_PUBLIC_KEY_PATH=~/my_public_key.pem
-```
-**Note:**  The **SGX_LE_SIGNING_MATERIAL** and **SGX_LE_PUBLIC_KEY_PATH** are NOT mandatory parameters.  
-**Note:**  To generate "Intel signed" compatible sigstruct file, add **INTEL_SIGNED=1** for each of the make commands.  
-
-#### Build Intel(R) SGX Driver using a pre-built Permissive LE  
-The Permissive LE (PLE) includes two headers representing the binary content of the PLE (sgx_le_blob.h) and the sigstruct (sgx_le_ss.h) located in the ```driver/le/enclave``` directory.  
-If these files exist, the PLE will not be built and they will be integrated into the driver build. Use a single step make command to complete the driver build and integrate the PLE into it:
-```
-$ make 
-```
-
-**Note:** To ensure execution of the PLE build when **NOT** using pre-built PLE, clean all the previously built content before any other build command:
+To clean the build area and remove all the generated and build files use:
 ```
 $ make clean
-``` 
-
+```
 ### Install the Intel(R) SGX Driver
-The Intel(R) SGX driver supports DKMS installation, to install the driver follow the following steps:  
+The Intel(R) SGX driver supports DKMS installation, to install the driver follow the following steps:
 - Ensure that the DKMS package is installed, or install it using:
   ``` $ sudo apt-get install dkms  ```
-- With root priviledge, copy the sources to ``/usr/src/sgx-<version>/`` 
-	- ``<version>`` should match the version specified in the dkms.conf file 
+- With root priviledge, copy the sources to ``/usr/src/sgx-<version>/``
+	- ``<version>`` should match the version specified in the dkms.conf file
 - Follow the following steps to add and install the driver into the DKMS tree:
 ```
 $ sudo dkms add -m sgx -v <version>
@@ -106,7 +62,7 @@ $ sudo dkms install -m sgx -v <version>
 $ sudo /sbin/modprobe intel_sgx
 ```
 ### Uninstall the Intel(R) SGX Driver
-To uninstall the Intel(R) SGX driver, enter the following commands with root privilege: 
+To uninstall the Intel(R) SGX driver, enter the following commands with root privilege:
 ```
 $ sudo /sbin/modprobe -r intel_sgx
 $ sudo dkms remove -m sgx -v <version> --all

--- a/driver/linux/dkms.conf
+++ b/driver/linux/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="sgx"
-PACKAGE_VERSION="1.21"
+PACKAGE_VERSION="1.22"
 BUILT_MODULE_NAME[0]="intel_sgx"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/intel/sgx"
 AUTOINSTALL="yes"

--- a/driver/linux/sgx_encl.c
+++ b/driver/linux/sgx_encl.c
@@ -881,7 +881,7 @@ int sgx_encl_init(struct sgx_encl *encl, struct sgx_sigstruct *sigstruct,
 
 	/* Check that the required attributes have been authorized. */
 	if (encl->attributes & ~encl->allowed_attributes)
-		return -EINVAL;
+		return -EACCES;
 
 	flush_work(&encl->add_page_work);
 

--- a/driver/linux/sgx_version.h
+++ b/driver/linux/sgx_version.h
@@ -55,6 +55,6 @@
 #define _SGX_VERSION_H
 
 #define DRV_DESCRIPTION "Intel SGX Driver"
-#define DRV_VERSION "1.21"
+#define DRV_VERSION "1.22"
 
 #endif /* _SGX_VERSION_H */


### PR DESCRIPTION
- Fail driver build when kernel is supporting SGX
- Fail with EACCES when trying to launch an enclave with provision bit set without proper permission
- Cleanup the readme file to reflect the PLE removal

Signed-off-by: Haim Cohen <haim.cohen@intel.com>