### PR TITLE
Fix QvE error code masking

### DIFF
--- a/QuoteVerification/QvE/Include/qve_header.h
+++ b/QuoteVerification/QvE/Include/qve_header.h
@@ -79,9 +79,7 @@
 #endif //CLEAR_FREE_MEM
 
 #define EXPECTED_CERTIFICATE_COUNT_IN_PCK_CHAIN 3
-#ifndef SGX_QL_MK_ERROR
 #define SGX_QL_MK_ERROR(x)              (0x0000A000|(x))
-#endif //SGX_QL_MK_ERROR
 /** Contains the possible values of the quote verification result. */
 typedef enum _sgx_ql_qv_result_t
 {


### PR DESCRIPTION
SGX_QL_MK_ERROR macro is also defined in sgx_ql_lib_common.h but with a
different mask. Because of the ifdefs in qve_header.h, QvE errors use the
same mask as sgx_ql_lib_common. This patch enables the two sets of error
codes to have different masks as was probably originally intended.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>