### PR TITLE
Revert "Fix incorrect key type constants"

### DIFF
--- a/QuoteVerification/QVL/Src/AttestationLibrary/src/QuoteVerification/QuoteConstants.h
+++ b/QuoteVerification/QVL/Src/AttestationLibrary/src/QuoteVerification/QuoteConstants.h
@@ -38,8 +38,8 @@ namespace intel { namespace sgx { namespace qvl { namespace constants {
 
 const uint16_t QUOTE_VERSION = 3;
 
-const uint16_t ECDSA_256_WITH_P256_CURVE = 2;
-const uint16_t ECDSA_384_WITH_P384_CURVE = 3;
+const uint16_t ECDSA_256_WITH_P256_CURVE = 1;
+const uint16_t ECDSA_384_WITH_P384_CURVE = 2;
 constexpr size_t ECDSA_P256_SIGNATURE_BYTE_LEN = 64;
 constexpr size_t ENCLAVE_REPORT_BYTE_LEN = 384;
 


### PR DESCRIPTION
Reverts intel/SGXDataCenterAttestationPrimitives#56

Need to sync with other SGX components.
Revert it now and will fix this issue later.