### PR TITLE
Fix driver compilation for latest kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /QuoteGeneration/build/
 **/Debug/
 **/Release/
+dcap.mod

--- a/driver/linux/Makefile
+++ b/driver/linux/Makefile
@@ -54,8 +54,8 @@
 
 ifneq ($(KERNELRELEASE),)
 
-obj-m += intel_sgx.o
-intel_sgx-y := \
+obj-m += dcap.o
+dcap-y := \
 	sgx_ioctl.o \
 	sgx_encl.o \
 	sgx_main.o \

--- a/driver/linux/Makefile
+++ b/driver/linux/Makefile
@@ -79,6 +79,9 @@ PWD  := $(shell pwd)
 default:
 	$(MAKE) -C $(KDIR) M=$(PWD) CFLAGS_MODULE="-I$(PWD) -I$(PWD)/include" modules
 
+install: default
+	$(MAKE) INSTALL_MOD_DIR=kernel/drivers/intel/sgx -C $(KDIR) M=$(PWD) modules_install
+
 endif
 endif
 

--- a/driver/linux/sgx.h
+++ b/driver/linux/sgx.h
@@ -78,14 +78,14 @@
         #define X86_FEATURE_SGX 			(9 * 32 + 2)
 #endif
 
-#define FEATURE_CONTROL_SGX_ENABLE			(1<<18)
+#define FEAT_CTL_SGX_ENABLED			(1<<18)
 
-#ifndef MSR_IA32_FEATURE_CONTROL
-    #define MSR_IA32_FEATURE_CONTROL 		0x0000003a
+#ifndef MSR_IA32_FEAT_CTL
+    #define MSR_IA32_FEAT_CTL 		0x0000003a
 #endif
 
-#ifndef FEATURE_CONTROL_SGX_LE_WR
-    #define FEATURE_CONTROL_SGX_LE_WR		(1<<17)
+#ifndef FEAT_CTL_SGX_LE_WR
+    #define FEAT_CTL_SGX_LE_WR		(1<<17)
 #endif
 
 #ifndef X86_FEATURE_SGX_LC

--- a/driver/linux/sgx_encl.c
+++ b/driver/linux/sgx_encl.c
@@ -940,8 +940,7 @@ void sgx_encl_release(struct kref *ref)
 	put_pid(encl->tgid);
 
 	if (encl->mmu_notifier.ops)
-		mmu_notifier_unregister_no_release(&encl->mmu_notifier,
-						   encl->mm);
+		mmu_notifier_put(&encl->mmu_notifier);
 
 	list_for_each_entry(entry, &encl->load_list, list)
 		sgx_free_page(entry->epc_page, encl);

--- a/driver/linux/sgx_main.c
+++ b/driver/linux/sgx_main.c
@@ -117,19 +117,19 @@ static bool sgx_is_enabled(void)
 		return false;
 	}
 
-	rdmsrl(MSR_IA32_FEATURE_CONTROL, fc);
-	if (!(fc & FEATURE_CONTROL_LOCKED)) {
-		pr_err("intel_sgx: FEATURE_CONTROL MSR is not locked!\n");
+	rdmsrl(MSR_IA32_FEAT_CTL, fc);
+	if (!(fc & FEAT_CTL_LOCKED)) {
+		pr_err("intel_sgx: FEAT_CTL MSR is not locked!\n");
 		return false;
 	}
 
-	if (!(fc & FEATURE_CONTROL_SGX_ENABLE)) {
-		pr_err("intel_sgx: SGX is not enalbed in FEATURE_CONTROL MSR!\n");
+	if (!(fc & FEAT_CTL_SGX_ENABLED)) {
+		pr_err("intel_sgx: SGX is not enalbed in FEAT_CTL MSR!\n");
 		return false;
 	}
 
-	if (!(fc & FEATURE_CONTROL_SGX_LE_WR)) {
-		pr_err("intel_sgx: FLC feature is not enalbed in FEATURE_CONTROL MSR!\n");
+	if (!(fc & FEAT_CTL_SGX_LE_WR)) {
+		pr_err("intel_sgx: FLC feature is not enalbed in FEAT_CTL MSR!\n");
 		return false;
 	}
 

--- a/driver/linux/sgx_page_cache.c
+++ b/driver/linux/sgx_page_cache.c
@@ -64,6 +64,7 @@
 #include <linux/version.h>
 #include <linux/sched/signal.h>
 #include <linux/slab.h>
+#include <linux/io.h>
 #include "sgx.h"
 
 #define SGX_NR_LOW_PAGES 32


### PR DESCRIPTION
Warnings still remain for this:

```
/tmp/SGXDataCenterAttestationPrimitives/driver/linux/sgx_main.c: In function ‘sgx_dev_init’:
/tmp/SGXDataCenterAttestationPrimitives/driver/linux/sgx_main.c:395:2: warning: ignoring return value of ‘sysfs_create_file’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  395 |  sysfs_create_file(sgx_dev->kobj_dir, &info_attr.attr);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/SGXDataCenterAttestationPrimitives/driver/linux/sgx_main.c:396:2: warning: ignoring return value of ‘sysfs_create_file’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  396 |  sysfs_create_file(sgx_dev->kobj_dir, &version_attr.attr);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

But I'm not a Linux kernel developer, so I'm not quite sure how to handle cleanup of those sysfs entries should one of those commands fail.