### PR TITLE
QuoteGeneration/Makefile: Fix incorrect usage of exit

### DIFF
--- a/QuoteGeneration/Makefile
+++ b/QuoteGeneration/Makefile
@@ -63,7 +63,7 @@ dcap: $(CHECK_OPT) pce_wrapper quote_wrapper qcnl_wrapper qpl_wrapper qve_wrappe
 opt_check_failed:
 	@echo "ERROR: Please decompress prebuilt enclave package before compiling."
 	@echo "Exiting......"
-	@exit -2
+	@exit 3
 
 pce_wrapper: 
 	$(MAKE) -C pce_wrapper/linux


### PR DESCRIPTION
`exit` with a negative argument is not supported by `sh`, thus leading to the following output:
```
ERROR: Please decompress prebuilt enclave package before compiling.
Exiting......
/bin/sh: 1: exit: Illegal number: -2
```