### PR TITLE
Check for SGX support with X86_FEATURE_SGX not X86_FEATURE_SGX1

### DIFF
--- a/driver/linux/main.c
+++ b/driver/linux/main.c
@@ -41,7 +41,7 @@ static bool detect_sgx(struct cpuinfo_x86 *c)
         return false;
     }
 
-    if (!cpu_has(c, X86_FEATURE_SGX1)) {
+    if (!cpu_has(c, X86_FEATURE_SGX)) {
         pr_err_once("sgx: SGX1 instruction set is not supported\n");
         return false;
     }


### PR DESCRIPTION
The value defined by X86_FEATURE_SGX is populated in the kernel's CPU feature bitmask by querying CPUID. This properly checks for SGX support. X86_FEATURE_SGX1 defines as value which is defined in kernel source as X86_FEATURE_TPR_SHADOW which is not a good proxy for SGX1 support.