### PR TITLE
Add module alias for ACPI device INT0E0C

### DIFF
--- a/driver/linux/driver.c
+++ b/driver/linux/driver.c
@@ -220,3 +220,11 @@ int __exit sgx_drv_exit(void)
 
 	return 0;
 }
+
+#ifdef CONFIG_ACPI
+static struct acpi_device_id sgx_device_ids[] = {
+	{"INT0E0C", 0},
+	{"", 0},
+};
+MODULE_DEVICE_TABLE(acpi, sgx_device_ids);
+#endif


### PR DESCRIPTION
The INT0E0C device denotes SGX support in the DSDT ACPI table. Add this as an alias to the SGX driver. This allows the module to be auto-probed when the module is build with the kernel (rather than DKMS) and the entry is present in the machine's DSDT.

There were also a couple things I noticed when trying to build the module as part of the kernel build:
1. The headers in driver/linux/include are not included. I had to copy them to driver/linux

Note: I compiled the driver into the kernel by symlinking driver/linux into the linux source tree (at drivers/platform/x86/sgx) and then modifying the Makefile at drivers/platform/x86

2. The latest tip of master can only build against 5.7+. I'm not sure if distros are responsible for back-porting to older kernels?