### PR TITLE
Linux Driver: fix enclave size validation

### DIFF
--- a/driver/linux/ioctl.c
+++ b/driver/linux/ioctl.c
@@ -97,7 +97,7 @@ static int sgx_validate_secs(const struct sgx_secs *secs)
 	    secs->xfrm & sgx_xfrm_reserved_mask)
 		return -EINVAL;
 
-	if (secs->size >= max_size)
+	if (secs->size > max_size)
 		return -EINVAL;
 
 	if (!(secs->xfrm & XFEATURE_MASK_FP) ||


### PR DESCRIPTION
This pull request fix enclave size validation on sgx_validate_secs() method. The current implementation of sgx_validate_secs breaks if maximum enclave size is used.