### PR TITLE
Fix signed integer overflow on shift

### DIFF
--- a/driver/linux/ioctl.c
+++ b/driver/linux/ioctl.c
@@ -66,7 +66,7 @@ static u32 sgx_calc_ssa_frame_size(u32 miscselect, u64 xfrm)
 	int i;
 
 	for (i = 2; i < 64; i++) {
-		if (!((1 << i) & xfrm))
+		if (!((1UL << i) & xfrm))
 			continue;
 
 		size = SGX_SSA_GPRS_SIZE + sgx_xsave_size_tbl[i];


### PR DESCRIPTION
Shifting a signed integer value of 1 by 31 or more bits will cause
overflow and can lead to undefined behaviour. Fix this by adding
a UL suffix to ensure an unsigned long is being shifted.

Signed-off-by: Colin Ian King colin.king@canonical.com
Signed-off-by: Haitao Huang <4699115+haitaohuang@users.noreply.github.com>