### PR TITLE
Linux Driver: Support SGX1 machine even without FLC support

### DIFF
--- a/driver/linux/driver.c
+++ b/driver/linux/driver.c
@@ -172,11 +172,6 @@ int __init sgx_drv_init(void)
 	int ret;
 	int i;
 
-	if (!boot_cpu_has(X86_FEATURE_SGX_LC)) {
-		pr_info("The public key MSRs are not writable.\n");
-		return -ENODEV;
-	}
-
 	cpuid_count(SGX_CPUID, 0, &eax, &ebx, &ecx, &edx);
 	sgx_misc_reserved_mask = ~ebx | SGX_MISC_RESERVED_MASK;
 	sgx_encl_size_max_64 = 1ULL << ((edx >> 8) & 0xFF);

--- a/driver/linux/include/uapi/asm/sgx_oot.h
+++ b/driver/linux/include/uapi/asm/sgx_oot.h
@@ -25,6 +25,8 @@ enum sgx_page_flags {
 	_IOWR(SGX_MAGIC, 0x01, struct sgx_enclave_add_pages)
 #define SGX_IOC_ENCLAVE_INIT \
 	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
+#define SGX_IOC_ENCLAVE_INIT_WITH_TOKEN \
+	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init_with_token)
 #define SGX_IOC_ENCLAVE_SET_ATTRIBUTE \
 	_IOW(SGX_MAGIC, 0x03, struct sgx_enclave_set_attribute)
 
@@ -64,6 +66,19 @@ struct sgx_enclave_add_pages {
 struct sgx_enclave_init {
 	__u64 sigstruct;
 };
+
+/*
+ * struct sgx_enclave_init_with_token - parameter structure for the
+ *                                      %SGX_IOC_ENCLAVE_INIT_WITH_TOKEN ioctl
+ * @addr:       address in the ELRANGE
+ * @sigstruct:  address for the SIGSTRUCT data
+ * @einittoken: address for the EINITTOKEN data
+ */
+struct sgx_enclave_init_with_token {
+	__u64 addr;
+	__u64 sigstruct;
+	__u64 einittoken;
+} __packed;
 
 /**
  * struct sgx_enclave_set_attribute - parameter structure for the

--- a/driver/linux/main.c
+++ b/driver/linux/main.c
@@ -549,7 +549,6 @@ static bool detect_sgx(struct cpuinfo_x86 *c)
 
     if (!(fc & FEAT_CTL_SGX_LC_ENABLED)) {
         pr_info_once("sgx: The launch control MSRs are not writable\n");
-        return false;
     }
 
     return true;


### PR DESCRIPTION
There are still lots of SGX1 machines without FLC support deployed
in filed. These machines eventually needs to be migrated to be supported
by SGX DCAP driver which is product-ready and well-maintained.

This patch targets to address the gap between SGX1 machine and SGX
DCAP driver.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>
Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>