### PR TITLE
Linux Driver: look for exported symbols in Makefile

### DIFF
--- a/driver/linux/Makefile
+++ b/driver/linux/Makefile
@@ -9,7 +9,15 @@ intel_sgx-y := encl.o main.o driver.o ioctl.o
 else
 
 KDIR := /lib/modules/$(shell uname -r)/build
-
+KSYM_MMPUT_ASYNC := $(shell grep  "mmput_async\svmlinux\sEXPORT" $(KDIR)/Module.symvers)
+KSYM_LOOKUP := $(shell grep "kallsyms_lookup_name\svmlinux\sEXPORT" $(KDIR)/Module.symvers)
+EXTRA_CFLAGS :=
+ifneq ($(KSYM_MMPUT_ASYNC),)
+	EXTRA_CFLAGS += -DHAVE_MMPUT_ASYNC
+endif
+ifneq ($(KSYM_LOOKUP),)
+	 EXTRA_CFLAGS += -DHAVE_KSYM_LOOKUP
+endif
 INKERNEL_SGX :=$(shell cat $(KDIR)/.config | grep "CONFIG_X86_SGX=y\|CONFIG_INTEL_SGX=y")
 ifneq ($(INKERNEL_SGX),)
 default:
@@ -19,7 +27,7 @@ else
 
 PWD  := $(shell pwd)
 default:
-	$(MAKE) -C $(KDIR) M=$(PWD) CFLAGS_MODULE="-I$(PWD) -I$(PWD)/include" modules
+	$(MAKE) -C $(KDIR) M=$(PWD) CFLAGS_MODULE="-I$(PWD) -I$(PWD)/include $(EXTRA_CFLAGS)" modules
 
 endif
 endif

--- a/driver/linux/main.c
+++ b/driver/linux/main.c
@@ -766,10 +766,15 @@ static int __init sgx_init(void)
 
 	if (!sgx_page_cache_init())
 		return -EFAULT;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0) )
-#pragma message "kernel version may not be supported"
-#endif
+#ifdef HAVE_MMPUT_ASYNC
+	k_mmput_async = mmput_async;
+#else
+#ifdef HAVE_KSYM_LOOKUP
 	k_mmput_async = (void*)kallsyms_lookup_name("mmput_async");
+#else
+	#error "kernel version is not be supported. We need either mmput_async or kallsyms_lookup_name exported from kernel"
+#endif
+#endif
 	if (!k_mmput_async){
 		pr_err("mmput_async support missing from kernel.\n");
 		return -EFAULT;


### PR DESCRIPTION
Different variant of distro kernels export different set of symbols.
Directly look for those needed in $(KDIR)/Module.symvers to avoid hardcoded kernel version

Signed-off-by: Haitao Huang <4699115+haitaohuang@users.noreply.github.com>