### PR TITLE
Fix rpm build failure for libsgx-dcap-ql

### DIFF
--- a/QuoteGeneration/installer/linux/rpm/libsgx-dcap-ql/build.sh
+++ b/QuoteGeneration/installer/linux/rpm/libsgx-dcap-ql/build.sh
@@ -66,8 +66,15 @@ post_build() {
 }
 
 update_spec() {
+    min_version="4.12"
+    rpm_version=$(rpmbuild --version 2> /dev/null | awk '{print $NF}')
+    cur_version=$(echo -e "${rpm_version}\n${min_version}" | sort -V | head -n 1)
+
     pushd ${SCRIPT_DIR}/${RPM_BUILD_FOLDER}
     sed -i "s/@version@/${SGX_VERSION}/" SPECS/${DCAP_QL_PACKAGE_NAME}.spec
+    if [ "${min_version}" != "${cur_version}" ]; then
+        sed -i "s/^Recommends:/Requires:  /" SPECS/${DCAP_QL_PACKAGE_NAME}.spec
+    fi
     popd
 }
 


### PR DESCRIPTION
This commit resolves the following build failure:

pkgroot/libsgx-dcap-ql-dev/include/
pkgroot/libsgx-dcap-ql-dev/include/sgx_dcap_ql_wrapper.h
~/downloads/alinux2/linux-sgx/external/dcap_source/QuoteGeneration
~/downloads/alinux2/linux-sgx/external/dcap_source/QuoteGeneration/installer/linux/rpm/libsgx-dcap-ql/libsgx-dcap-ql-1.10.100.4 ~/downloads/alinux2/linux-sgx/external/dcap_source/QuoteGeneration
error: line 40: Unknown tag: Recommends:     libsgx-dcap-quote-verify >= 1.10.100.4-1.al7
make[1]: *** [Makefile:121: rpm_sgx_dcap_ql_pkg] Error 1
make[1]: Leaving directory '/root/downloads/alinux2/linux-sgx/external/dcap_source/QuoteGeneration'
make: *** [Makefile:265: rpm_libsgx_dcap_ql] Error 2

The fix refers to libsgx-dcap-quote-verify/build.sh.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>