### PR TITLE
Return PEM-encoded data for pckcrl and rootcacrl

### DIFF
--- a/QuoteGeneration/pccs/services/pckcrlService.js
+++ b/QuoteGeneration/pccs/services/pckcrlService.js
@@ -46,7 +46,14 @@ export async function getPckCrl(ca) {
 
   // To keep backward compatibility. 
   // TODO : for PCS alignment, need to remove this conversion
-  result['pckcrl'] = Buffer.from(result['pckcrl'], 'utf8').toString('hex');
+  result['pckcrl'] = derToPem(Buffer.from(result['pckcrl'], 'utf8'))
 
   return result;
 }
+
+function derToPem(der) {
+    var prefix = '-----BEGIN X509 CRL-----\n';
+    var postfix = '-----END X509 CRL-----';
+    return prefix + der.toString('base64').match(/.{0,64}/g).join('\n') + postfix;
+}
+


### PR DESCRIPTION
The problem is when using Java CertifcateFactory - it accepts either PEM (ascii) or DER (binary) data.
However existing code return hex string for pckcrl and rootcacrl.
Azure plugin returns all certs and crls in pem format.
It would be great if PCCS did the same.
The proposed change also applies to rootcacrlService.js:
  crl = derToPem(Buffer.from(crl, 'utf8'));