### PR TITLE
Remove conversion to hex string

### DIFF
--- a/QuoteGeneration/pccs/services/rootcacrlService.js
+++ b/QuoteGeneration/pccs/services/rootcacrlService.js
@@ -47,8 +47,5 @@ export async function getRootCaCrl() {
     crl = await cachingModeManager.getRootCACrlFromPCS(rootca);
   }
 
-  // To keep backward compatibility. 
-  crl = Buffer.from(crl, 'utf8').toString('hex');
-  
   return crl;
 }


### PR DESCRIPTION
Remove the conversion to hex encoded string for pckcrl and rootcacrl.

According to the [API specification](https://api.portal.trustedservices.intel.com/documentation#pcs-revocation-v3), Get Revocation List should return the CRL either PEM or DER encoded.
The PCCS implementation provided in this repo currently does neither by returning the CRL in DER format but encoded as a hex string.

As mentioned in this issue: https://github.com/intel/SGXDataCenterAttestationPrimitives/issues/186, general QPL implementation expects the CRL to be in the correct format.
For example OpenEnclave is currently unable to verify quotes using the reference PCCS implementation and default Intel QPL because of this issue, since it is unable to correctly read the CRLs returned by PCCS: https://github.com/openenclave/openenclave/blob/6522cf8a6760d5ad728ec9af3d38749d3ec51513/common/sgx/collateral.c#L292