### PR TITLE
[QVL] Fix current locale being modified

### DIFF
--- a/QuoteVerification/QVL/Src/AttestationCommons/src/Utils/TimeUtils.cpp
+++ b/QuoteVerification/QVL/Src/AttestationCommons/src/Utils/TimeUtils.cpp
@@ -155,7 +155,7 @@ namespace standard
     {
         struct tm date_c{};
         std::istringstream input(date);
-        input.imbue (std::locale(setlocale(LC_ALL, "")));
+        input.imbue (std::locale(setlocale(LC_ALL, nullptr)));
         input >> std::get_time(&date_c, "%Y-%m-%dT%H:%M:%SZ");
         return date_c;
     }


### PR DESCRIPTION
When using [gramine](https://github.com/gramineproject/gramine) to run a secure python app,  I need the locale set to "C.UTF-8", but the  `getTimeFromString`  sets it to the native environment by assigning new locale to "" (refer to `man 3 setlocale`),  so it leads crash in function `sgx_qv_verify_quote`.

I think when we use `getTimeFromString`, we don't have to reset the locale.