### PR TITLE
Correctly identify configuration files in RPM spec files

### DIFF
--- a/tools/PCKRetrievalTool/installer/rpm/sgx-pck-id-retrieval-tool/sgx-pck-id-retrieval-tool.spec
+++ b/tools/PCKRetrievalTool/installer/rpm/sgx-pck-id-retrieval-tool/sgx-pck-id-retrieval-tool.spec
@@ -56,7 +56,7 @@ find %{?buildroot} | sort | \
 awk '$0 !~ last "/" {print last} {last=$0} END {print last}' | \
 sed -e "s#^%{?buildroot}##" | \
 grep -v "^%{_install_path}" >> %{_specdir}/list-%{name} || :
-sed -i 's#^/etc/rad.conf#%config &#' %{_specdir}/list-%{name}
+echo "%config %{_install_path}/network_setting.conf" >> %{_specdir}/list-%{name}
 
 %files -f %{_specdir}/list-%{name}
 

--- a/tools/SGXPlatformRegistration/package/installer/rpm/sgx-ra-service/sgx-ra-service.spec
+++ b/tools/SGXPlatformRegistration/package/installer/rpm/sgx-ra-service/sgx-ra-service.spec
@@ -56,7 +56,7 @@ find %{?buildroot} | sort | \
 awk '$0 !~ last "/" {print last} {last=$0} END {print last}' | \
 sed -e "s#^%{?buildroot}##" | \
 grep -v "^%{_install_path}" >> %{_specdir}/list-%{name} || :
-sed -i 's#^/etc/rad.conf#%config &#' %{_specdir}/list-%{name}
+sed -i 's#^/etc/mpa_registration.conf#%config &#' %{_specdir}/list-%{name}
 
 %files -f %{_specdir}/list-%{name}
 


### PR DESCRIPTION
In RPM spec files it is desirable to prefix configuration files with "%config"
in order to preserve/save any user modifications during RPM upgrade.

Fix sgx-ra-service.spec:
The spec file attempts to prefix "/etc/rad.conf" with prefix %config.
There is no /etc/rad.conf file being packaged. The configuration file
that is actually packaged is "/etc/mpa_registration.conf".

Fix sgx-pck-id-retrieval-tool.spec
The spec file attempts to prefix "/etc/rad.conf" with prefix %config.
There is no /etc/rad.conf file being packaged. The config file we actually
want to prefix with %config is "network_setting.conf". Although this file
is distributed, it is not listed in "%{_specdir}/list-%name".
"%{_specdir}/list-%name" only contains the name of the installation folder
"%{_install_path}". It is unclear if this was intended, most likely not.
Hence we cannot use "sed" for prefixing. Instead of mdifying a presumably
existing line with "sed" we simply append "%{_specdir}/list-%name" with the
desired line.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>