### PR TITLE
Call cp(1) relative to `PATH`

### DIFF
--- a/QuoteGeneration/buildenv.mk
+++ b/QuoteGeneration/buildenv.mk
@@ -52,7 +52,7 @@ SGX_VER:= $(shell awk '$$2 ~ /STRFILEVER/ { print substr($$3, 2, length($$3) - 2
 SGX_MAJOR_VER:= $(shell echo $(SGX_VER) |awk -F. '{print $$1}')
 SPLIT_VERSION=$(word $2,$(subst ., ,$1))
 
-CP    := /bin/cp -f
+CP    := cp -f
 MKDIR := mkdir -p
 STRIP := strip
 OBJCOPY := objcopy

--- a/tools/SGXPlatformRegistration/Makefile
+++ b/tools/SGXPlatformRegistration/Makefile
@@ -29,7 +29,7 @@
 #
 #
 
-CP    := /bin/cp -f
+CP    := cp -f
 MKDIR := mkdir -p
 
 PACKAGE_DIR := package

--- a/tools/SGXPlatformRegistration/buildenv.mk
+++ b/tools/SGXPlatformRegistration/buildenv.mk
@@ -37,7 +37,7 @@ LOCAL_COMMON_DIR  := $(ROOT_DIR)/common
 INCLUDE_DIR := $(ROOT_DIR)/include
 LIBS_DIR := $(ROOT_DIR)/build/lib64
 BINS_DIR := $(ROOT_DIR)/build/bin
-CP := /bin/cp -f
+CP := cp -f
 
 
 RA_VERSION= $(shell awk '$$2 ~ /STRFILEVER/ { print substr($$3, 2, length($$3) - 2); }' $(ROOT_DIR)/../../QuoteGeneration/common/inc/internal/se_version.h)


### PR DESCRIPTION
In contrast to other coreutils binaries used throughout the code,
cp(1) gets called with an absolute path which assumes the binary
resides in `/bin`. This commit removes the absolute path to search
for cp(1) relative to the search paths given in the `PATH`
environment variable.

Using an absolute path to call binaries is incompatible with
distributions which do not follow the Filesystem Hierachy Standard;
NixOS is an example. Also, as other coreutils binaries merely mention
the binary's name, it is more consistent to call cp(1) in the same way.

Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>
