### PR TITLE
Update libsgx-dcap-ql installer package dependency

### DIFF
--- a/QuoteGeneration/installer/linux/deb/libsgx-dcap-ql/libsgx-dcap-ql-1.0/debian/control
+++ b/QuoteGeneration/installer/linux/deb/libsgx-dcap-ql/libsgx-dcap-ql-1.0/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/intel/SGXDataCenterAttestationPrimitives
 
 Package: libsgx-dcap-ql
 Architecture: amd64
-Depends: libsgx-qe3-logic(>= @dep_version@), libsgx-pce-logic(>= @dep_version@), libsgx-ae-qve(>= @dep_version@), ${shlibs:Depends}, ${misc:Depends}
+Depends: libsgx-qe3-logic(>= @dep_version@), libsgx-pce-logic(>= @dep_version@), ${shlibs:Depends}, ${misc:Depends}
 Recommends: libsgx-dcap-quote-verify(>= @dep_version@), libsgx-quote-ex(>= 2.15)
 Description: Intel(R) Software Guard Extensions Data Center Attestation Primitives
 

--- a/QuoteGeneration/installer/linux/rpm/libsgx-dcap-ql/libsgx-dcap-ql.spec
+++ b/QuoteGeneration/installer/linux/rpm/libsgx-dcap-ql/libsgx-dcap-ql.spec
@@ -36,7 +36,7 @@ Version:        @version@
 Release:        1%{?dist}
 Summary:        Intel(R) Software Guard Extensions Data Center Attestation Primitives
 Group:          Development/Libraries
-Requires:       libsgx-qe3-logic >= %{version}-%{release} libsgx-pce-logic >= %{version}-%{release} libsgx-ae-qve >= %{version}-%{release}
+Requires:       libsgx-qe3-logic >= %{version}-%{release} libsgx-pce-logic >= %{version}-%{release}
 Recommends:     libsgx-dcap-quote-verify >= %{version}-%{release} libsgx-quote-ex >= 2.15
 
 License:        BSD License


### PR DESCRIPTION
libsgx-dcap-ql package doesn't depends on libsgx-ae-qve package.
Users have to install unnecessary and unwanted package due to this incorrect Depends/Requires.

Fixes [#linux-sgx/756](https://github.com/intel/linux-sgx/issues/756)