### PR TITLE
Fix libsgx-pce-logic and libsgx-qe3-logic deb installer

### DIFF
--- a/QuoteGeneration/installer/linux/common/libsgx-pce-logic/Makefile
+++ b/QuoteGeneration/installer/linux/common/libsgx-pce-logic/Makefile
@@ -41,7 +41,6 @@ default:
 install: $(PACKAGES)
 
 $(PACKAGES):
-	install -d $(shell readlink -m $(DESTDIR)/$@)
 	$(if $(wildcard $(PACKAGE_ROOT_FOLDER)/$@/$(LIB_DIR)/*.so), \
 		install -d $(shell readlink -m $(DESTDIR)/$(USR_LIB_PATH)) && \
 		mv $(PACKAGE_ROOT_FOLDER)/$@/$(LIB_DIR)/*.so $(DESTDIR)/$(USR_LIB_PATH))

--- a/QuoteGeneration/installer/linux/common/libsgx-qe3-logic/Makefile
+++ b/QuoteGeneration/installer/linux/common/libsgx-qe3-logic/Makefile
@@ -41,7 +41,6 @@ default:
 install: $(PACKAGES)
 
 $(PACKAGES):
-	install -d $(shell readlink -m $(DESTDIR)/$@)
 	$(if $(wildcard $(PACKAGE_ROOT_FOLDER)/$@/$(LIB_DIR)/*.so), \
 		install -d $(shell readlink -m $(DESTDIR)/$(USR_LIB_PATH)) && \
 		mv $(PACKAGE_ROOT_FOLDER)/$@/$(LIB_DIR)/*.so $(DESTDIR)/$(USR_LIB_PATH))


### PR DESCRIPTION
Remove unused empty folder `/libsgx-pce-logic` and `/libsgx-pce-logic` in root folder after `libsgx-pce-logic` and `libsgx-qe3-logic` deb installers installed.

No such issue found on RPM based OS and this fix doesn't change RPM installer behavior.

fixes https://github.com/intel/linux-sgx/issues/762
