### PR TITLE
Fix post-installation script of pccs

### DIFF
--- a/QuoteGeneration/pccs/startup.sh
+++ b/QuoteGeneration/pccs/startup.sh
@@ -44,7 +44,7 @@ if [ ! $(getent group $PCCS_USER) ]; then
     groupadd $PCCS_USER
 fi
 if ! id "$PCCS_USER" &>/dev/null; then
-    adduser --system $PCCS_USER -g $PCCS_USER --home $PCCS_HOME --no-create-home --shell /bin/bash
+    adduser --system $PCCS_USER --group --home $PCCS_HOME --no-create-home --shell /bin/bash
 fi
 chown -R $PCCS_USER:$PCCS_USER $PCCS_HOME
 chmod 640 $PCCS_HOME/config/default.json


### PR DESCRIPTION
This issue was identified during installing `sgx-dcap-pccs_1.13.100.1-jammy1_amd64.deb` which was built from sgx psw source code. the `dpkg` reports the following error message and stopped. To continue, the bug has to be fixed up.
`subprocess installed post-installation script returned error exit status 1`