### PR TITLE
Fix missing include in qgs

### DIFF
--- a/QuoteGeneration/quote_wrapper/qgs/Makefile
+++ b/QuoteGeneration/quote_wrapper/qgs/Makefile
@@ -41,6 +41,7 @@ PROTOBUF_CFLAGS = `pkg-config --cflags protobuf-lite`
 QGS_INC = -I$(SGX_SDK)/include \
 		  -I$(COMMON_DIR)/inc/internal \
 		  -I$(TOP_DIR)/qpl/inc \
+		  -I$(TOP_DIR)/quote_wrapper/common/inc \
 		  -I$(TOP_DIR)/quote_wrapper/tdx_quote
 QGS_CFLAGS = -g  -MMD $(CFLAGS) $(QGS_INC) $(PROTOBUF_CFLAGS)
 QGS_CXXFLAGS = -g  -MMD $(CXXFLAGS) $(QGS_INC) $(PROTOBUF_CFLAGS)


### PR DESCRIPTION
The `qgs_server.cpp` depends on a header file located in the `quote_wrapper/common/inc` folder, which is not specified in the include list, preventing the build.