### PR TITLE
Update Rust QVL APIs

### DIFF
--- a/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-rs/Cargo.toml
+++ b/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sgx-dcap-quoteverify-rs"
-version = "0.1.0"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sgx-dcap-quoteverify-sys = { version = "0.1.0", path = "../sgx-dcap-quoteverify-sys" }
+sgx-dcap-quoteverify-sys = { version = "0.2.0", path = "../sgx-dcap-quoteverify-sys" }

--- a/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-rs/src/lib.rs
+++ b/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-rs/src/lib.rs
@@ -31,10 +31,11 @@
 //! Intel(R) Software Guard Extensions Data Center Attestation Primitives (Intel(R) SGX DCAP)
 //! Rust wrapper for Quote Verification Library
 //! ================================================
-//! 
+//!
 //! This is a safe wrapper for **sgx-dcap-quoteverify-sys**.
 
 use std::ffi::CString;
+use std::slice;
 use sgx_dcap_quoteverify_sys as qvl_sys;
 
 pub use qvl_sys::quote3_error_t;
@@ -45,7 +46,7 @@ pub use qvl_sys::tdx_ql_qve_collateral_t;
 pub use qvl_sys::sgx_ql_qv_result_t;
 pub use qvl_sys::sgx_ql_qe_report_info_t;
 pub use qvl_sys::sgx_qv_path_type_t;
-
+pub use qvl_sys::tee_supp_data_descriptor_t;
 
 /// When the Quoting Verification Library is linked to a process, it needs to know the proper enclave loading policy.
 /// The library may be linked with a long lived process, such as a service, where it can load the enclaves and leave
@@ -59,8 +60,7 @@ pub use qvl_sys::sgx_qv_path_type_t;
 ///
 /// # Param
 /// - **policy**\
-/// Sets the requested enclave loading policy to either *SGX_QL_PERSISTENT*, *SGX_QL_EPHEMERAL*
-/// or *SGX_QL_DEFAULT*.
+/// Set the requested enclave loading policy to either *SGX_QL_PERSISTENT*, *SGX_QL_EPHEMERAL* or *SGX_QL_DEFAULT*.
 ///
 /// # Return
 /// - ***SGX_QL_SUCCESS***\
@@ -73,25 +73,22 @@ pub use qvl_sys::sgx_qv_path_type_t;
 /// # Examples
 /// ```
 /// use sgx_dcap_quoteverify_rs::*;
-/// 
+///
 /// let policy = sgx_ql_request_policy_t::SGX_QL_DEFAULT;
 /// let ret = sgx_qv_set_enclave_load_policy(policy);
-/// 
+///
 /// assert_eq!(ret, quote3_error_t::SGX_QL_SUCCESS);
 /// ```
 pub fn sgx_qv_set_enclave_load_policy(policy: sgx_ql_request_policy_t) -> quote3_error_t {
-    unsafe {qvl_sys::sgx_qv_set_enclave_load_policy(policy)}
+    unsafe { qvl_sys::sgx_qv_set_enclave_load_policy(policy) }
 }
 
 /// Get SGX supplemental data required size.
 ///
-/// # Param
-/// - **p_data_size\[OUT\]**\
-/// Pointer to hold the size of the buffer in bytes required to contain all of the supplemental data.
-///
 /// # Return
+/// Size of the supplemental data in bytes.
+///
 /// Status code of the operation, one of:
-/// - *SGX_QL_SUCCESS*
 /// - *SGX_QL_ERROR_INVALID_PARAMETER*
 /// - *SGX_QL_ERROR_QVL_QVE_MISMATCH*
 /// - *SGX_QL_ENCLAVE_LOAD_ERROR*
@@ -99,42 +96,43 @@ pub fn sgx_qv_set_enclave_load_policy(policy: sgx_ql_request_policy_t) -> quote3
 /// # Examples
 /// ```
 /// use sgx_dcap_quoteverify_rs::*;
-/// 
-/// let mut data_size: u32 = 0;
-/// let ret = sgx_qv_get_quote_supplemental_data_size(&mut data_size);
-/// 
-/// assert_eq!(ret, quote3_error_t::SGX_QL_SUCCESS);
+///
+/// let data_size = sgx_qv_get_quote_supplemental_data_size().unwrap();
+///
 /// assert_eq!(data_size, std::mem::size_of::<sgx_ql_qv_supplemental_t>() as u32);
 /// ```
-pub fn sgx_qv_get_quote_supplemental_data_size(p_data_size: &mut u32) -> quote3_error_t {
-    unsafe {qvl_sys::sgx_qv_get_quote_supplemental_data_size(p_data_size as *mut u32)}
+pub fn sgx_qv_get_quote_supplemental_data_size() -> Result<u32, quote3_error_t> {
+    let mut data_size = 0u32;
+    unsafe {
+        match qvl_sys::sgx_qv_get_quote_supplemental_data_size(&mut data_size) {
+            quote3_error_t::SGX_QL_SUCCESS => Ok(data_size),
+            error_code => Err(error_code),
+        }
+    }
 }
 
 /// Perform SGX ECDSA quote verification.
 ///
 /// # Param
-/// - **quote\[IN\]**\
+/// - **quote**\
 /// SGX Quote, presented as u8 vector.
-/// - **p_quote_collateral\[IN\]**\
-/// This is a pointer to the Quote Certification Collateral provided by the caller.
-/// - **expiration_check_date\[IN\]**\
+/// - **quote_collateral**\
+/// Quote Certification Collateral provided by the caller.
+/// - **expiration_check_date**\
 /// This is the date that the QvE will use to determine if any of the inputted collateral have expired.
-/// - **p_collateral_expiration_status\[OUT\]**\
-/// Address of the outputted expiration status.  This input must not be NULL.
-/// - **p_quote_verification_result\[OUT\]**\
-/// Address of the outputted quote verification result.
-/// - **p_qve_report_info\[IN/OUT\]**\
+/// - **qve_report_info**\
 /// This parameter can be used in 2 ways.\
-///     - If p_qve_report_info is NOT None, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.\
-///     - if p_qve_report_info is None, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
-/// - **supplemental_data_size\[IN\]**\
-/// Size of the buffer pointed to by p_quote (in bytes).
-/// - **p_supplemental_data\[OUT\]**\
-/// The parameter is optional.  If it is None, supplemental_data_size must be 0.
+///     - If qve_report_info is NOT None, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.\
+///     - if qve_report_info is None, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
+/// - **supplemental_data_size**\
+/// Size of the supplemental data (in bytes).
+/// - **supplemental_data**\
+/// The parameter is optional. If it is None, supplemental_data_size must be 0.
 ///
 /// # Return
+/// Result type of (collateral_expiration_status, verification_result)
+///
 /// Status code of the operation, one of:
-/// - *SGX_QL_SUCCESS*
 /// - *SGX_QL_ERROR_INVALID_PARAMETER*
 /// - *SGX_QL_QUOTE_FORMAT_UNSUPPORTED*
 /// - *SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED*
@@ -144,53 +142,55 @@ pub fn sgx_qv_get_quote_supplemental_data_size(p_data_size: &mut u32) -> quote3_
 ///
 pub fn sgx_qv_verify_quote(
     quote: &[u8],
-    p_quote_collateral: Option<&sgx_ql_qve_collateral_t>,
+    quote_collateral: Option<&sgx_ql_qve_collateral_t>,
     expiration_check_date: i64,
-    p_collateral_expiration_status: &mut u32,
-    p_quote_verification_result: &mut sgx_ql_qv_result_t,
-    p_qve_report_info: Option<&mut sgx_ql_qe_report_info_t>,
+    qve_report_info: Option<&mut sgx_ql_qe_report_info_t>,
     supplemental_data_size: u32,
-    p_supplemental_data: Option<&mut sgx_ql_qv_supplemental_t>
-) -> quote3_error_t {
+    supplemental_data: Option<&mut sgx_ql_qv_supplemental_t>,
+) -> Result<(u32, sgx_ql_qv_result_t), quote3_error_t> {
 
-    // Match Option types to raw pointers
-    //
-    let p_quote_collateral = match p_quote_collateral {
-        Some(p) => p as *const sgx_ql_qve_collateral_t,
+    let mut collateral_expiration_status = 1u32;
+    let mut quote_verification_result = sgx_ql_qv_result_t::SGX_QL_QV_RESULT_UNSPECIFIED;
+
+    let p_quote_collateral = match quote_collateral {
+        Some(p) => p,
         None => std::ptr::null(),
     };
-    let p_qve_report_info = match p_qve_report_info {
-        Some(p) => p as *mut sgx_ql_qe_report_info_t,
+    let p_qve_report_info = match qve_report_info {
+        Some(p) => p,
         None => std::ptr::null_mut(),
     };
-    let p_supplemental_data = match p_supplemental_data {
+    let p_supplemental_data = match supplemental_data {
         Some(p) => p as *mut sgx_ql_qv_supplemental_t as *mut u8,
         None => std::ptr::null_mut(),
     };
 
     unsafe {
-        qvl_sys::sgx_qv_verify_quote(
+        match qvl_sys::sgx_qv_verify_quote(
             quote.as_ptr(),
             quote.len() as u32,
             p_quote_collateral,
             expiration_check_date,
-            p_collateral_expiration_status as *mut u32,
-            p_quote_verification_result as *mut sgx_ql_qv_result_t,
+            &mut collateral_expiration_status,
+            &mut quote_verification_result,
             p_qve_report_info,
             supplemental_data_size,
-            p_supplemental_data)
+            p_supplemental_data,
+        ) {
+            quote3_error_t::SGX_QL_SUCCESS => {
+                Ok((collateral_expiration_status, quote_verification_result))
+            }
+            error_code => Err(error_code),
+        }
     }
 }
 
 /// Get TDX supplemental data required size.
 ///
-/// # Param
-/// - **p_data_size\[OUT\]**\
-/// Pointer to hold the size of the buffer in bytes required to contain all of the supplemental data.
-///
 /// # Return
+/// Size of the supplemental data in bytes.
+///
 /// Status code of the operation, one of:
-/// - *SGX_QL_SUCCESS*
 /// - *SGX_QL_ERROR_INVALID_PARAMETER*
 /// - *SGX_QL_ERROR_QVL_QVE_MISMATCH*
 /// - *SGX_QL_ENCLAVE_LOAD_ERROR*
@@ -198,42 +198,43 @@ pub fn sgx_qv_verify_quote(
 /// # Examples
 /// ```
 /// use sgx_dcap_quoteverify_rs::*;
-/// 
-/// let mut data_size: u32 = 0;
-/// let ret = tdx_qv_get_quote_supplemental_data_size(&mut data_size);
-/// 
-/// assert_eq!(ret, quote3_error_t::SGX_QL_SUCCESS);
+///
+/// let data_size = tdx_qv_get_quote_supplemental_data_size().unwrap();
+///
 /// assert_eq!(data_size, std::mem::size_of::<sgx_ql_qv_supplemental_t>() as u32);
 /// ```
-pub fn tdx_qv_get_quote_supplemental_data_size(p_data_size: &mut u32) -> quote3_error_t {
-    unsafe {qvl_sys::tdx_qv_get_quote_supplemental_data_size(p_data_size as *mut u32)}
+pub fn tdx_qv_get_quote_supplemental_data_size() -> Result<u32, quote3_error_t> {
+    let mut data_size = 0u32;
+    unsafe {
+        match qvl_sys::tdx_qv_get_quote_supplemental_data_size(&mut data_size) {
+            quote3_error_t::SGX_QL_SUCCESS => Ok(data_size),
+            error_code => Err(error_code),
+        }
+    }
 }
 
 /// Perform TDX ECDSA quote verification.
 ///
 /// # Param
-/// - **quote\[IN\]**\
+/// - **quote**\
 /// TDX Quote, presented as u8 vector.
-/// - **p_quote_collateral\[IN\]**\
-/// This is a pointer to the Quote Certification Collateral provided by the caller.
-/// - **expiration_check_date\[IN\]**\
+/// - **quote_collateral**\
+/// Quote Certification Collateral provided by the caller.
+/// - **expiration_check_date**\
 /// This is the date that the QvE will use to determine if any of the inputted collateral have expired.
-/// - **p_collateral_expiration_status\[OUT\]**\
-/// Address of the outputted expiration status.  This input must not be NULL.
-/// - **p_quote_verification_result\[OUT\]**\
-/// Address of the outputted quote verification result.
-/// - **p_qve_report_info\[IN/OUT\]**\
+/// - **qve_report_info**\
 /// This parameter can be used in 2 ways.\
-///     - If p_qve_report_info is NOT None, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.\
-///     - if p_qve_report_info is None, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
-/// - **supplemental_data_size\[IN\]**\
-/// Size of the buffer pointed to by p_quote (in bytes).
-/// - **p_supplemental_data\[OUT\]**\
-/// The parameter is optional.  If it is None, supplemental_data_size must be 0.
+///     - If qve_report_info is NOT None, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.\
+///     - if qve_report_info is None, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
+/// - **supplemental_data_size**\
+/// Size of the supplemental data (in bytes).
+/// - **supplemental_data**\
+/// The parameter is optional. If it is None, supplemental_data_size must be 0.
 ///
 /// # Return
+/// Result type of (collateral_expiration_status, verification_result)
+///
 /// Status code of the operation, one of:
-/// - *SGX_QL_SUCCESS*
 /// - *SGX_QL_ERROR_INVALID_PARAMETER*
 /// - *SGX_QL_QUOTE_FORMAT_UNSUPPORTED*
 /// - *SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED*
@@ -243,41 +244,46 @@ pub fn tdx_qv_get_quote_supplemental_data_size(p_data_size: &mut u32) -> quote3_
 ///
 pub fn tdx_qv_verify_quote(
     quote: &[u8],
-    p_quote_collateral: Option<&tdx_ql_qve_collateral_t>,
+    quote_collateral: Option<&tdx_ql_qve_collateral_t>,
     expiration_check_date: i64,
-    p_collateral_expiration_status: &mut u32,
-    p_quote_verification_result: &mut sgx_ql_qv_result_t,
-    p_qve_report_info: Option<&mut sgx_ql_qe_report_info_t>,
+    qve_report_info: Option<&mut sgx_ql_qe_report_info_t>,
     supplemental_data_size: u32,
-    p_supplemental_data: Option<&mut sgx_ql_qv_supplemental_t>
-) -> quote3_error_t {
+    supplemental_data: Option<&mut sgx_ql_qv_supplemental_t>,
+) -> Result<(u32, sgx_ql_qv_result_t), quote3_error_t> {
 
-    // Match Option types to raw pointers
-    //
-    let p_quote_collateral = match p_quote_collateral {
-        Some(p) => p as *const tdx_ql_qve_collateral_t,
+    let mut collateral_expiration_status = 1u32;
+    let mut quote_verification_result = sgx_ql_qv_result_t::SGX_QL_QV_RESULT_UNSPECIFIED;
+
+    let p_quote_collateral = match quote_collateral {
+        Some(p) => p,
         None => std::ptr::null(),
     };
-    let p_qve_report_info = match p_qve_report_info {
-        Some(p) => p as *mut sgx_ql_qe_report_info_t,
+    let p_qve_report_info = match qve_report_info {
+        Some(p) => p,
         None => std::ptr::null_mut(),
     };
-    let p_supplemental_data = match p_supplemental_data {
+    let p_supplemental_data = match supplemental_data {
         Some(p) => p as *mut sgx_ql_qv_supplemental_t as *mut u8,
         None => std::ptr::null_mut(),
     };
 
     unsafe {
-        qvl_sys::tdx_qv_verify_quote(
+        match qvl_sys::tdx_qv_verify_quote(
             quote.as_ptr(),
             quote.len() as u32,
             p_quote_collateral,
             expiration_check_date,
-            p_collateral_expiration_status as *mut u32,
-            p_quote_verification_result as *mut sgx_ql_qv_result_t,
+            &mut collateral_expiration_status,
+            &mut quote_verification_result,
             p_qve_report_info,
             supplemental_data_size,
-            p_supplemental_data)
+            p_supplemental_data,
+        ) {
+            quote3_error_t::SGX_QL_SUCCESS => {
+                Ok((collateral_expiration_status, quote_verification_result))
+            }
+            error_code => Err(error_code),
+        }
     }
 }
 
@@ -287,16 +293,173 @@ pub fn tdx_qv_verify_quote(
 /// # Param
 /// - **path_type**\
 /// The type of binary being passed in.
-/// - **p_path**\
+/// - **path**\
 /// It should be a valid full path.
 ///
 /// # Return
 /// - ***SGX_QL_SUCCESS***\
 /// Successfully set the full path.
 /// - ***SGX_QL_ERROR_INVALID_PARAMETER***\
-/// p_path is not a valid full path or the path is too long.
+/// path is not a valid full path or the path is too long.
 ///
 #[cfg(target_os = "linux")]
-pub fn sgx_qv_set_path(path_type: sgx_qv_path_type_t,  p_path: CString) -> quote3_error_t {
-    unsafe {qvl_sys::sgx_qv_set_path(path_type, p_path.as_ptr())}
+pub fn sgx_qv_set_path(path_type: sgx_qv_path_type_t, path: &str) -> quote3_error_t {
+    match CString::new(path) {
+        Ok(path) => unsafe { qvl_sys::sgx_qv_set_path(path_type, path.as_ptr()) }
+        _ => quote3_error_t::SGX_QL_ERROR_INVALID_PARAMETER,
+    }
+}
+
+/// Get quote verification collateral.
+///
+/// # Param
+/// - **quote**\
+/// SGX/TDX Quote, presented as u8 vector.
+///
+/// # Return
+/// Result type of quote_collecteral
+///
+/// - **quote_collateral**\
+/// This is the Quote Certification Collateral retrieved based on Quote.
+///
+/// Status code of the operation, one of:
+/// - *SGX_QL_ERROR_INVALID_PARAMETER*
+/// - *SGX_QL_PLATFORM_LIB_UNAVAILABLE*
+/// - *SGX_QL_PCK_CERT_CHAIN_ERROR*
+/// - *SGX_QL_PCK_CERT_UNSUPPORTED_FORMAT*
+/// - *SGX_QL_QUOTE_FORMAT_UNSUPPORTED*
+/// - *SGX_QL_OUT_OF_MEMORY*
+/// - *SGX_QL_NO_QUOTE_COLLATERAL_DATA*
+/// - *SGX_QL_ERROR_UNEXPECTED*
+///
+pub fn tee_qv_get_collateral(quote: &[u8]) -> Result<Vec<u8>, quote3_error_t> {
+    let mut buf = std::ptr::null_mut();
+    let mut buf_len = 0u32;
+
+    unsafe {
+        match qvl_sys::tee_qv_get_collateral(
+            quote.as_ptr(),
+            quote.len() as u32,
+            &mut buf,
+            &mut buf_len,
+        ) {
+            quote3_error_t::SGX_QL_SUCCESS => {
+                let collateral = slice::from_raw_parts(buf, buf_len as usize).to_vec();
+                match qvl_sys::tee_qv_free_collateral(buf) {
+                    quote3_error_t::SGX_QL_SUCCESS => Ok(collateral),
+                    error_code => Err(error_code),
+                }
+            }
+            error_code => Err(error_code),
+        }
+    }
+}
+
+/// Get supplemental data latest version and required size, support both SGX and TDX
+///
+/// # Param
+/// - **quote**\
+/// SGX/TDX Quote, presented as u8 vector.
+///
+/// # Return
+/// Result type of (version, data_size) tuple
+///
+/// - **version**\
+/// Latest version of the supplemental data.
+/// - **data_size**\
+/// The size of the buffer in bytes required to contain all of the supplemental data.
+///
+pub fn tee_get_supplemental_data_version_and_size(
+    quote: &[u8],
+) -> Result<(u32, u32), quote3_error_t> {
+    let mut version = 0u32;
+    let mut data_size = 0u32;
+
+    unsafe {
+        match qvl_sys::tee_get_supplemental_data_version_and_size(
+            quote.as_ptr(),
+            quote.len() as u32,
+            &mut version,
+            &mut data_size,
+        ) {
+            quote3_error_t::SGX_QL_SUCCESS => Ok((version, data_size)),
+            error_code => Err(error_code),
+        }
+    }
+}
+
+/// Perform quote verification for SGX and TDX
+/// This API works the same as the old one, but takes a new parameter to describe the supplemental data (p_supp_data_descriptor)
+///
+/// # Param
+/// - **quote**\
+/// SGX/TDX Quote, presented as u8 vector.
+/// - **quote_collateral**\
+/// Quote Certification Collateral provided by the caller.
+/// - **expiration_check_date**\
+/// This is the date that the QvE will use to determine if any of the inputted collateral have expired.
+/// - **qve_report_info**\
+/// This parameter can be used in 2 ways.\
+///     - If qve_report_info is NOT None, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.\
+///     - if qve_report_info is None, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
+/// - **supp_datal_descriptor**\
+/// *tee_supp_data_descriptor_t* structure.
+/// You can specify the major version of supplemental data by setting supp_datal_descriptor.major_version
+/// If supp_datal_descriptor is None, no supplemental data is returned.
+/// If supp_datal_descriptor.major_version == 0, then return the latest version of the *sgx_ql_qv_supplemental_t* structure.
+/// If supp_datal_descriptor <= latest supported version, return the latest minor version associated with that major version.
+/// If supp_datal_descriptor > latest supported version, return an error *SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED*.
+///
+/// # Return
+/// Result type of (collateral_expiration_status, verification_result)
+///
+/// Status code of the operation, one of:
+/// - *SGX_QL_ERROR_INVALID_PARAMETER*
+/// - *SGX_QL_QUOTE_FORMAT_UNSUPPORTED*
+/// - *SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED*
+/// - *SGX_QL_UNABLE_TO_GENERATE_REPORT*
+/// - *SGX_QL_CRL_UNSUPPORTED_FORMAT*
+/// - *SGX_QL_ERROR_UNEXPECTED*
+///
+pub fn tee_verify_quote(
+    quote: &[u8],
+    quote_collateral: Option<&[u8]>,
+    expiration_check_date: i64,
+    qve_report_info: Option<&mut sgx_ql_qe_report_info_t>,
+    supp_data_descriptor: Option<&mut tee_supp_data_descriptor_t>,
+) -> Result<(u32, sgx_ql_qv_result_t), quote3_error_t> {
+
+    let mut collateral_expiration_status = 1u32;
+    let mut quote_verification_result = sgx_ql_qv_result_t::SGX_QL_QV_RESULT_UNSPECIFIED;
+
+    let p_quote_collateral = match quote_collateral {
+        Some(p) => p.as_ptr(),
+        None => std::ptr::null(),
+    };
+    let p_qve_report_info = match qve_report_info {
+        Some(p) => p,
+        None => std::ptr::null_mut(),
+    };
+    let p_supp_data_descriptor = match supp_data_descriptor {
+        Some(p) => p,
+        None => std::ptr::null_mut(),
+    };
+
+    unsafe {
+        match qvl_sys::tee_verify_quote(
+            quote.as_ptr(),
+            quote.len() as u32,
+            p_quote_collateral,
+            expiration_check_date,
+            &mut collateral_expiration_status,
+            &mut quote_verification_result,
+            p_qve_report_info,
+            p_supp_data_descriptor,
+        ) {
+            quote3_error_t::SGX_QL_SUCCESS => {
+                Ok((collateral_expiration_status, quote_verification_result))
+            }
+            error_code => Err(error_code),
+        }
+    }
 }

--- a/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys/Cargo.toml
+++ b/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sgx-dcap-quoteverify-sys"
-version = "0.1.0"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 links = "sgx_dcap_quoteverify"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,4 +9,4 @@ links = "sgx_dcap_quoteverify"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = "0.60.1"

--- a/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys/build.rs
+++ b/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys/build.rs
@@ -44,12 +44,9 @@ fn main() {
 
     // Set sdk to search path if SGX_SDK is in environment variable
     let mut sdk_inc = String::from("-I");
-    match env::var("SGX_SDK") {
-        Ok(val) => {
-            sdk_inc.push_str(&val);
-            sdk_inc.push_str("/include/");
-        },
-        _ => (),
+    if let Ok(val) = env::var("SGX_SDK") {
+        sdk_inc.push_str(&val);
+        sdk_inc.push_str("/include/");
     }
 
     // The bindgen::Builder is the main entry point
@@ -66,13 +63,15 @@ fn main() {
         .rustified_enum("_sgx_ql_request_policy")
         .rustified_enum("_sgx_ql_qv_result_t")
         .rustified_enum("sgx_qv_path_type_t")
-        // Disable debug trait for packed C structures
+        // Disable Debug trait for packed C structures
         .no_debug("_quote_t")
         .no_debug("_sgx_ql_auth_data_t")
         .no_debug("_sgx_ql_certification_data_t")
         .no_debug("_sgx_ql_ecdsa_sig_data_t")
         .no_debug("_sgx_quote3_t")
         .no_debug("_sgx_ql_att_key_id_param_t")
+        // Enable Default trait
+        .derive_default(true)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys/src/lib.rs
+++ b/QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys/src/lib.rs
@@ -39,10 +39,9 @@
 //! * Intel(R) SGX DCAP PCCS (Provisioning Certificate Caching Service)
 //!
 //! *Please refer to [SGX DCAP Linux installation guide](
-//! https://download.01.org/intel-sgx/sgx-dcap/#version#/linux/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf)
+//! https://download.01.org/intel-sgx/latest/linux-latest/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf)
 //! to install above dependencies.*
 //! 
-//! *Note that you need to change **\#version\#** to actual version number in URL, such as 1.4.*\
 //! *Note that you need to install **libsgx-dcap-quote-verify-dev** and **clang** for this package.*
 
 #![allow(non_upper_case_globals)]

--- a/SampleCode/RustQuoteVerificationSample/Cargo.toml
+++ b/SampleCode/RustQuoteVerificationSample/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "app"
-version = "0.1.0"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sgx-dcap-quoteverify-rs = { path = "../../QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-rs"}
-sgx-dcap-quoteverify-sys = { path = "../../QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys"}
-clap = "2.34"
+clap = { version = "4.0", features = ["derive"] }
+sgx-dcap-quoteverify-rs = { version = "0.2.0", path = "../../QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-rs"}
+sgx-dcap-quoteverify-sys = { version = "0.2.0", path = "../../QuoteVerification/dcap_quoteverify/sgx-dcap-quoteverify-sys"}
+
+[features]
+TD_ENV = []

--- a/SampleCode/RustQuoteVerificationSample/README.md
+++ b/SampleCode/RustQuoteVerificationSample/README.md
@@ -70,3 +70,9 @@ Prerequisite:
    ```
    $ cargo run -- --quote </path/to/quote.dat>
    ```
+
+3. Build and run *RustQuoteVerificationSample* in TD VM:
+
+```
+cargo run --features TD_ENV
+```


### PR DESCRIPTION
1. Use `Result` for returning errors
2. Add new API to get collateral
3. Add new `tee` APIs to get supplemental data size and verify quote
4. Upgrade Rust edition to 2021
5. Update sample code to use `tee` APIs instead of the old `sgx` APIs
6. Add `TD_ENV` feature to the sample code to support running on TDX environment

Signed-off-by: yao-ji <yao.ji@intel.com>