### PR TITLE
tdx-attest-sys: fix build.rs

### DIFF
--- a/QuoteGeneration/quote_wrapper/tdx-attest-sys/build.rs
+++ b/QuoteGeneration/quote_wrapper/tdx-attest-sys/build.rs
@@ -43,9 +43,10 @@ fn main() {
     println!("cargo:rerun-if-changed=bindings.h");
 
     // Set sdk to search path if SGX_SDK is in environment variable
-    let mut sdk_inc = String::from("-I");
+    let mut sdk_inc = String::from("");
     match env::var("SGX_SDK") {
         Ok(val) => {
+            sdk_inc.push_str("-I");
             sdk_inc.push_str(&val);
             sdk_inc.push_str("/include/");
         },

--- a/QuoteGeneration/quote_wrapper/tdx-attest-sys/build.rs
+++ b/QuoteGeneration/quote_wrapper/tdx-attest-sys/build.rs
@@ -40,7 +40,7 @@ fn main() {
     println!("cargo:rustc-link-lib=tdx_attest");
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes
-    println!("cargo:rerun-if-changed=bingings.h");
+    println!("cargo:rerun-if-changed=bindings.h");
 
     // Set sdk to search path if SGX_SDK is in environment variable
     let mut sdk_inc = String::from("-I");


### PR DESCRIPTION
- typo in `cargo:rerun-if-changed=` specification
- wrong clang args passed when SGX_SDK is not defined