### PR TITLE
Fix QVL/QvE build failure in Windows on TDX 1.5 branch

### DIFF
--- a/QuoteVerification/QvE/AttestationLibrary/AttestationLibrary.vcxproj
+++ b/QuoteVerification/QvE/AttestationLibrary/AttestationLibrary.vcxproj
@@ -147,7 +147,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts_sim.lib;sgx_tstdc.lib;sgx_tservice_sim.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>
@@ -169,7 +169,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>
@@ -191,7 +191,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>
@@ -212,7 +212,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
       <AdditionalOptions>/d2FH4- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -234,7 +234,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
       <AdditionalOptions>/d2FH4- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -257,7 +257,7 @@
       <PreprocessorDefinitions>NDEBUG;SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC;OPENSSL_NO_FILENAMES</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
       <AdditionalOptions>/d2FH4- %(AdditionalOptions)</AdditionalOptions>
       <UseFullPaths>false</UseFullPaths>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -285,7 +285,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>
@@ -301,7 +301,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>

--- a/QuoteVerification/QvE/AttestationParsers/AttestationParsers.vcxproj
+++ b/QuoteVerification/QvE/AttestationParsers/AttestationParsers.vcxproj
@@ -316,6 +316,9 @@
     <ClCompile Include="..\..\QVL\Src\AttestationCommons\src\Utils\TimeUtils.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TcbComponent.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModule.cpp" />
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleIdentity.cpp" />
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcb.cpp" />
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcbLevel.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\ParserUtils.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\X509\Configuration.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\X509\PlatformPckCertificate.cpp" />

--- a/QuoteVerification/QvE/AttestationParsers/AttestationParsers.vcxproj.filters
+++ b/QuoteVerification/QvE/AttestationParsers/AttestationParsers.vcxproj.filters
@@ -72,5 +72,14 @@
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModule.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleIdentity.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcbLevel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/QuoteVerification/dcap_quoteverify/AttestationLibrary_untrusted/AttestationLibrary_untrusted.vcxproj
+++ b/QuoteVerification/dcap_quoteverify/AttestationLibrary_untrusted/AttestationLibrary_untrusted.vcxproj
@@ -90,7 +90,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>
@@ -111,7 +111,7 @@
       <PreprocessorDefinitions>_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>
@@ -134,7 +134,7 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC;OPENSSL_NO_FILENAMES</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
       <UseFullPaths>false</UseFullPaths>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -163,7 +163,7 @@
       <PreprocessorDefinitions>SGX_TRUSTED;_WINDOWS;ATTESTATIONLIBRARY_STATIC;ATTESTATIONPARSERS_STATIC</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <DisableSpecificWarnings>4101</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4101;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>sgx_trts.lib;sgx_tstdc.lib;sgx_tservice.lib;sgx_tcxx.lib;sgx_tcrypto.lib</AdditionalDependencies>

--- a/QuoteVerification/dcap_quoteverify/AttestationParsers_untrusted/AttestationParsers_untrusted.vcxproj
+++ b/QuoteVerification/dcap_quoteverify/AttestationParsers_untrusted/AttestationParsers_untrusted.vcxproj
@@ -173,6 +173,9 @@
     <ClCompile Include="..\..\QVL\Src\AttestationCommons\src\Utils\TimeUtils.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TcbComponent.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModule.cpp" />
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleIdentity.cpp" />
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcb.cpp" />
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcbLevel.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\ParserUtils.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\X509\Configuration.cpp" />
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\X509\PlatformPckCertificate.cpp" />

--- a/QuoteVerification/dcap_quoteverify/AttestationParsers_untrusted/AttestationParsers_untrusted.vcxproj.filters
+++ b/QuoteVerification/dcap_quoteverify/AttestationParsers_untrusted/AttestationParsers_untrusted.vcxproj.filters
@@ -72,5 +72,14 @@
     <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModule.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleIdentity.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\QVL\Src\AttestationParsers\src\Json\TdxModuleTcbLevel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix QVL/QvE build failure in Windows on TDX 1.5 branch.
- QVL/QvE need to add TDX related files in VS project.
- Ignore the warning which introduced in latest SDK C++ runtime.