### PR TITLE
[PccsAdminTool] Fix keyword argument of urllib3.util.Retry

### DIFF
--- a/tools/PccsAdminTool/lib/intelsgx/pcs.py
+++ b/tools/PccsAdminTool/lib/intelsgx/pcs.py
@@ -56,7 +56,7 @@ class PCS:
         
         PARAMS = {}
         https = requests.Session()
-        https.mount("https://", HTTPAdapter(max_retries=Retry(method_whitelist=["HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS", "TRACE"])))
+        https.mount("https://", HTTPAdapter(max_retries=Retry(allowed_methods=["HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS", "TRACE"])))
         r = https.get(url = url, headers=headers, params = PARAMS, verify=True)
 
         return r
@@ -71,7 +71,7 @@ class PCS:
         
         PARAMS = {}
         https = requests.Session()
-        https.mount("https://", HTTPAdapter(max_retries=Retry(method_whitelist=["HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS", "TRACE"])))
+        https.mount("https://", HTTPAdapter(max_retries=Retry(allowed_methods=["HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS", "TRACE"])))
         r = https.post(url = url, headers=headers, params = PARAMS, data=json.dumps(data), verify=True)
 
         return r

--- a/tools/PccsAdminTool/requirements.txt
+++ b/tools/PccsAdminTool/requirements.txt
@@ -1,4 +1,5 @@
 requests
+urllib3>=1.26.0,<2.0.0
 asn1
 pyOpenSSL
 pypac


### PR DESCRIPTION
PccsAdminTool raises an exception when a request is sent to Intel PCS API if requirements are installed in a fresh virtual environment (tested on Ubuntu 22.04):

```console
$ cd tools/PccsAdminTool
$ python3 -m venv .venv
$ source .venv/bin/activate
$ python3 -m pip install -r requirements.txt
```

The reason is `urllib3==2.0.4` is installed (latest version compatible with `requests`) and `method_whitelist` keyword argument of `urllib3.util.Retry()` has been removed in favor of `allowed_methods`.

This PR fixes the issue but note that it's also possible to add an upper bound `urllib3<2.0` in `requirements.txt` for a quick fix.