### PR TITLE
QuoteGeneration/README.md: Correct installers path descriptions.

### DIFF
--- a/QuoteGeneration/README.md
+++ b/QuoteGeneration/README.md
@@ -120,7 +120,7 @@ A `README.md` is provided in the Intel(R) SGX driver package for Intel(R) SGX DC
   ```
     $ make deb_pkg
   ```
-  You can find the generated installers located under `linux/installer/deb/`.
+  You can find the generated installers located under `installer/linux/deb/`.
   **Note**: On Ubuntu 18.04 and Ubuntu 20.04, the above command also generates another debug symbol package with extension name of `.ddeb` for debug purpose.
   **Note**: The above command builds the installers with default configuration firstly and then generates the target installers. To build the installers without optimization and with full debug information kept in the libraries, enter the following command:
   ```
@@ -130,7 +130,7 @@ A `README.md` is provided in the Intel(R) SGX driver package for Intel(R) SGX DC
   ```
     $ make rpm_pkg
   ```
-  You can find the generated installers located under `linux/installer/rpm/`.
+  You can find the generated installers located under `installer/linux/rpm/`.
   **Note**: The above command builds the installers with default configuration firstly and then generates the target installers. To build the installers without optimization and with full debug information kept in the libraries, enter the following command:
   ```
     $ make rpm_pkg DEBUG=1


### PR DESCRIPTION
After I built the Intel(R) SGX DCAP Quote Generation Library and the Intel(R) SGX Default Quote Provider Library installers, I couldn't find the generated installers located.

```bash
$ cd linux/installer/deb/
cd: no such file or directory: linux/installer/deb/
```

The reason is that the README description is wrong. The correct path should be `installer/linux/deb`.

```bash
$ cd installer/linux/deb
```