### PR TITLE
Added active waiting for cmake-js (Text file busy) race condiion

### DIFF
--- a/QuoteVerification/QuoteVerificationService/Dockerfile
+++ b/QuoteVerification/QuoteVerificationService/Dockerfile
@@ -51,8 +51,8 @@ COPY src /qvs/src
 COPY configuration-default /qvs/configuration-default
 # build QVS
 RUN echo 'cmake_QVL_PATH=/qvl/Build/Release/dist' >> /qvs/src/.npmrc # workaround for npm 9+ https://github.com/npm/cli/issues/5852
-RUN cd /qvs/src && npm install
-# copy compiled bianries
+RUN cd /qvs/src && npm install && npm run wait-for-cmake-js && npm run build-native # workaournd for Text file busy race condition https://github.com/nodejs/docker-node/issues/1918
+# copy compiled binaries
 RUN mkdir -p /qvs/native/lib/ \
  && cp /qvl/Build/Release/dist/lib/*.so /qvs/native/lib/ \
  && cp /qvs/src/qvl/cmake-build-release/Release/*.node /qvs/native/ \

--- a/QuoteVerification/QuoteVerificationService/src/package.json
+++ b/QuoteVerification/QuoteVerificationService/src/package.json
@@ -1,7 +1,8 @@
 {
     "name": "quoteverificationservice",
     "scripts": {
-        "install": "cmake-js build -d qvl/ -O qvl/cmake-build-release",
+        "wait-for-cmake-js": "timeout 10s bash -c 'until cmake-js --version; do sleep 1; done'",
+        "build-native": "cmake-js build -d qvl/ -O qvl/cmake-build-release",
         "swagger": "node swagger.js"
     },
     "version": "1.0.0",


### PR DESCRIPTION
QVS is  always building with latest version of node:lts-slim image.
Latest version of node image is affected by race conditions, and running cmake-js instantly after npm install fails with "Text file busy" error on docker containers.
https://github.com/nodejs/docker-node/issues/1918

As a workaround package script 'wait-for-cmake-js' has been added.
It tries every second (up to 10 seconds) to use simplest --version command on cmake-js to test if cmake-js became operable.
