### PR TITLE
Fix PCCS docker build failure caused by missing Intel SDK

### DIFF
--- a/QuoteGeneration/buildenv.mk
+++ b/QuoteGeneration/buildenv.mk
@@ -67,8 +67,11 @@ SGX_ARCH ?= x64
 SGX_DEBUG ?= 0
 
 ifndef _TD_MIGRATION
-    ifneq ($(MAKECMDGOALS),clean)
+    ifneq ($(origin SGX_SDK),file)
     include $(SGX_SDK)/buildenv.mk
+    else
+$(info You may need to set environment variables if the SGX SDK is installed.)
+$(info Use a command like 'source /opt/intel/sgxsdk/environment')
     endif
 endif
 


### PR DESCRIPTION
Check to see if the Intel SGX SDK is explicitly specified. If it is, include the appropriate environment file. Otherwise, display a warning message that the Intel SDK is missing.