### PR TITLE
qgs: add --verbose & --debug parameters to control logging

### DIFF
--- a/QuoteGeneration/quote_wrapper/qgs/qgs_log.cpp
+++ b/QuoteGeneration/quote_wrapper/qgs/qgs_log.cpp
@@ -36,6 +36,8 @@
 #include "qgs_log.h"
 
 static bool _nosyslog = false;
+bool qgs_debug = false;
+bool qgs_verbose = false;
 
 void qgs_log_init(void)
 {
@@ -67,6 +69,9 @@ void sgx_proc_log_report(int level, const char *format, ...)
     // Make sure strlen(format) >= 1
     // so we can always add newline
     if (!format || !(*format))
+        return;//ignore
+    if (!qgs_verbose &&
+        level == QGS_LOG_LEVEL_INFO)
         return;//ignore
     va_start(ap, format);
     switch(level){

--- a/QuoteGeneration/quote_wrapper/qgs/qgs_log.h
+++ b/QuoteGeneration/quote_wrapper/qgs/qgs_log.h
@@ -40,6 +40,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif/*__cplusplus*/
+    extern bool qgs_debug;
+    extern bool qgs_verbose;
     void qgs_log_init(void);
     void qgs_log_init_ex(bool nosyslog);
     void qgs_log_fini(void);

--- a/QuoteGeneration/quote_wrapper/qgs/qgs_ql_logic.cpp
+++ b/QuoteGeneration/quote_wrapper/qgs/qgs_ql_logic.cpp
@@ -113,8 +113,8 @@ namespace intel { namespace sgx { namespace dcap { namespace qgs {
                 sgx_ql_set_logging_callback_t ql_set_logging_callback =
                     (sgx_ql_set_logging_callback_t)dlsym(p_handle, "sgx_ql_set_logging_callback");
                 if (dlerror() == NULL && ql_set_logging_callback) {
-                    // Set log level to SGX_QL_LOG_ERROR
-                    ql_set_logging_callback(sgx_ql_logging_callback, SGX_QL_LOG_ERROR);
+                    ql_set_logging_callback(sgx_ql_logging_callback,
+                                            qgs_debug ? SGX_QL_LOG_INFO : SGX_QL_LOG_ERROR);
                 } else {
                     QGS_LOG_WARN("Failed to set logging callback for the quote provider library.\n");
                 }
@@ -355,8 +355,8 @@ namespace intel { namespace sgx { namespace dcap { namespace qgs {
                 sgx_ql_set_logging_callback_t ql_set_logging_callback =
                     (sgx_ql_set_logging_callback_t)dlsym(p_handle, "sgx_ql_set_logging_callback");
                 if (dlerror() == NULL && ql_set_logging_callback) {
-                    // Set log level to SGX_QL_LOG_ERROR
-                    ql_set_logging_callback(sgx_ql_logging_callback, SGX_QL_LOG_ERROR);
+                    ql_set_logging_callback(sgx_ql_logging_callback,
+                                            qgs_debug ? SGX_QL_LOG_INFO : SGX_QL_LOG_ERROR);
                 } else {
                     QGS_LOG_WARN("Failed to set logging callback for the quote provider library.\n");
                 }

--- a/QuoteGeneration/quote_wrapper/qgs/qgs_ql_logic.cpp
+++ b/QuoteGeneration/quote_wrapper/qgs/qgs_ql_logic.cpp
@@ -50,10 +50,10 @@ typedef quote3_error_t (*sgx_ql_set_logging_callback_t)(sgx_ql_logging_callback_
 
 void sgx_ql_logging_callback(sgx_ql_log_level_t level, const char *message) {
     if (level == SGX_QL_LOG_ERROR) {
-        sgx_proc_log_report(1, message);
+        sgx_proc_log_report(1, "%s", message);
 
     } else if (level == SGX_QL_LOG_INFO) {
-        sgx_proc_log_report(3, message);
+        sgx_proc_log_report(3, "%s", message);
     }
 }
 

--- a/QuoteGeneration/quote_wrapper/qgs/server_main.cpp
+++ b/QuoteGeneration/quote_wrapper/qgs/server_main.cpp
@@ -85,7 +85,7 @@ int main(int argc, const char* argv[])
     unsigned long int num_threads = 0;
     char *endptr = NULL;
     if (argc > 4) {
-        cout << "Usage: " << argv[0] << "[--no-daemon] [-p=port_number] [-n=number_threads]"
+        cout << "Usage: " << argv[0] << " [--no-daemon] [-p=port_number] [-n=number_threads]"
              << endl;
         exit(1);
     }
@@ -181,7 +181,7 @@ int main(int argc, const char* argv[])
             cout << "thread number [" << num_threads << "] found in cmdline" << endl;
             continue;
         } else {
-            cout << "Usage: " << argv[0] << "[--no-daemon] [-p=port_number] [-n=number_threads]"
+            cout << "Usage: " << argv[0] << " [--no-daemon] [-p=port_number] [-n=number_threads]"
                 << endl;
             exit(1);
         }

--- a/QuoteGeneration/quote_wrapper/qgs/server_main.cpp
+++ b/QuoteGeneration/quote_wrapper/qgs/server_main.cpp
@@ -85,7 +85,7 @@ int main(int argc, const char* argv[])
     unsigned long int num_threads = 0;
     char *endptr = NULL;
     if (argc > 4) {
-        cout << "Usage: " << argv[0] << " [--no-daemon] [-p=port_number] [-n=number_threads]"
+        cout << "Usage: " << argv[0] << " [--no-daemon] [-p=port_number] [-n=number_threads] [--verbose] [--debug]"
              << endl;
         exit(1);
     }
@@ -153,6 +153,12 @@ int main(int argc, const char* argv[])
                  << endl;
             no_daemon = true;
             continue;
+        } else if (strcmp(argv[i], "--debug") == 0) {
+            qgs_verbose = qgs_debug = true;
+            continue;
+        } else if (strcmp(argv[i], "--verbose") == 0) {
+            qgs_verbose = true;
+            continue;
         } else if (strncmp(argv[i], "-p=", 3 ) == 0) {
             if (strspn(argv[i] + 3, "0123456789") != strlen(argv[i] + 3)) {
                 cout << "Please input valid port number" << endl;
@@ -181,7 +187,7 @@ int main(int argc, const char* argv[])
             cout << "thread number [" << num_threads << "] found in cmdline" << endl;
             continue;
         } else {
-            cout << "Usage: " << argv[0] << " [--no-daemon] [-p=port_number] [-n=number_threads]"
+            cout << "Usage: " << argv[0] << " [--no-daemon] [-p=port_number] [-n=number_threads] [--verbose] [--debug]"
                 << endl;
             exit(1);
         }


### PR DESCRIPTION
The interesting stuff is in the third commit...

Currently qgs prints all log messages to syslog or stderr unconditionally, even those at QGS_LOG_LEVEL_INFO. At the same time it hardcodes SGX_QL_LOG_ERROR for the quote provider library making it impossible to debug that part of the code.
    
This adds --verbose and --debug parameters to QGS with the following behaviour
    
 * Messages from QGS code at QGS_LOG_LEVEL_INFO are discarded unless --verbose is set. This makes QGS quiet by default, only printing warnings/errors.
* Messages from the quote provider library are requested at SGX_QL_LOG_INFO instead of SGX_QL_LOG_ERROR if --debug
is set. This output is very volumous, dumping HTTP request and response info, hence putting it behind --debug, instead of enabling it with the former --verbose flag.
* Enabling --debug will imply --verbose, so setting both is redundant, albeit harmless

The first two commits just fix two tiny bugs