### PR TITLE
pccsadmin: remove leftover debugging 'print(args)' statement

### DIFF
--- a/tools/PccsAdminTool/pccsadmin.py
+++ b/tools/PccsAdminTool/pccsadmin.py
@@ -92,7 +92,6 @@ def main():
         parser.print_help()
         parser.exit()
 
-    print(args)
     # Check mandatory arguments for appraisalpolicy
     if args.command == 'put' and args.url and args.url.endswith("/appraisalpolicy"):
         if not args.fmspc or not args.input_file:


### PR DESCRIPTION
Dumping the python "Namespace" object to stdout after parsing argv serves no user purpose. Remove what is presumably a leftover debugging statement.