### PR TITLE
ae: blank out ld-linux.so interpretor path from AEs

### DIFF
--- a/QuoteGeneration/ae/buildenv.mk
+++ b/QuoteGeneration/ae/buildenv.mk
@@ -58,8 +58,8 @@ LDTFLAGS_NO_CRYPTO = -L$(SGX_LIBRARY_PATH) -Wl,--whole-archive $(TRTSLIB) -Wl,--
             -Wl,--start-group $(EXTERNAL_LIB_NO_CRYPTO) -Wl,--end-group                    \
             -Wl,--version-script=$(WORK_DIR)/enclave.lds $(ENCLAVE_LDFLAGS)
 
-LDTFLAGS += -Wl,-Map=out.map -Wl,--undefined=version -Wl,--gc-sections
-LDTFLAGS_NO_CRYPTO += -Wl,-Map=out.map -Wl,--undefined=version -Wl,--gc-sections
+LDTFLAGS += -Wl,-Map=out.map -Wl,--undefined=version -Wl,--gc-sections -Wl,-dynamic-linker,
+LDTFLAGS_NO_CRYPTO += -Wl,-Map=out.map -Wl,--undefined=version -Wl,--gc-sections -Wl,-dynamic-linker,
 
 
 vpath %.cpp $(COMMON_DIR)/src:$(LINUX_PSW_DIR)/ae/common

--- a/QuoteVerification/QvE/Makefile
+++ b/QuoteVerification/QvE/Makefile
@@ -98,7 +98,8 @@ ENCLAVE_LDFLAGS := -Wl,-z,relro,-z,now,-z,noexecstack -shared \
 				   -Wl,--build-id		\
 				   -Wl,-Bdynamic -L$(SERVTD_ATTEST_BUILD_DIR) -ltdx_verify \
 				   -Wl,-L/lib/x86_64-linux-gnu/ -lc \
-				   -Wl,--version-script=Enclave/linux/qve_migration.lds
+				   -Wl,--version-script=Enclave/linux/qve_migration.lds \
+				   -Wl,--dynamic-linker,
 else
 ENCLAVE_LDFLAGS := -Wl,-z,relro,-z,now,-z,noexecstack -fPIC \
 				   -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles \
@@ -110,7 +111,8 @@ ENCLAVE_LDFLAGS := -Wl,-z,relro,-z,now,-z,noexecstack -fPIC \
 				   -Wl,-pie,-eenclave_entry -Wl,--export-dynamic -Wl,-Map,qve.map \
 				   -Wl,--defsym,__ImageBase=0  \
 				   -Wl,--build-id		\
-				   -Wl,--version-script=Enclave/linux/qve.lds
+				   -Wl,--version-script=Enclave/linux/qve.lds \
+				   -Wl,--dynamic-linker,
 endif
 
 


### PR DESCRIPTION
The enclaves are getting built as ELF executables, and thus the linker will embed the current ld-linux.so path for the host OS environment in the binary:

 $ readelf -a libsgx_tdqe.signed.so | grep interpreter
      [Requesting program interpreter: /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2]

The SGX enclaves are never loaded using ld-linux.so, as SGX has custom code for loading enclaves in the required manner.

This embedded ld-linux.so path thus serves no functional purpose, while also making it harder to do a reproducible build of the enclaves outside of the NixOS environment.

This patch blanks out the NixOX interpretor path, by setting it to the empty string.

Related: https://github.com/intel/linux-sgx/issues/1040

This is the DCAP counterpart to this SGX PR: https://github.com/intel/linux-sgx/pull/1061