### PR TITLE
sgxssl: enable pointing sgxssl build to alternative glibc headers

### DIFF
--- a/QuoteVerification/prepare_sgxssl.sh
+++ b/QuoteVerification/prepare_sgxssl.sh
@@ -67,12 +67,12 @@ fi
 
 pushd $sgxssl_dir/Linux/
 if [[ "$*" == *SERVTD_ATTEST* ]];then
-  make clean sgxssl_no_mitigation NO_THREADS=1 LINUX_SGX_BUILD=2 SERVTD_ATTEST=1
+  make clean sgxssl_no_mitigation ENCLAVE_SYSTEM_INCLUDES="$ENCLAVE_SYSTEM_INCLUDES" NO_THREADS=1 LINUX_SGX_BUILD=2 SERVTD_ATTEST=1
 else
   if [[ "$*" == *FIPS* ]];then
-    make clean sgxssl_no_mitigation FIPS=1
+    make clean sgxssl_no_mitigation ENCLAVE_SYSTEM_INCLUDES="$ENCLAVE_SYSTEM_INCLUDES" FIPS=1
   else
-    make clean sgxssl_no_mitigation
+    make clean sgxssl_no_mitigation ENCLAVE_SYSTEM_INCLUDES="$ENCLAVE_SYSTEM_INCLUDES"
   fi
 fi
 popd


### PR DESCRIPTION
The enclave musts be built with headers from a specific glibc version for the sake of reproducibility. It does not actually link to glibc, merely requiring a few self contained definitions. In the NixOS build env the glibc system include directories get set through various wrapper scripts NixOS creates.

When attempting a reproducible build outside of NixOS though, we can't rely on the compiler having the matching glibc system include dirs. Instead there needs to be a way to inject "-isystem/some/path" args into the enclave compiler flags.

A related commit in the SGX SDK buildenv.mk adds support for a "ENCLAVE_SYSTEM_INCLUDES" make var that can be set by the person triggering 'make', to provide a way to inject system include directories to the enclave build process.

This commit sures that $(ENCLAVE_SYSTEM_INCLUDES) is passed on to the build of sgxssl.