### PR TITLE
fix: add missing comma in sgx_default_qcnl_intelpcs.conf

### DIFF
--- a/QuoteGeneration/qcnl/linux/sgx_default_qcnl_intelpcs.conf
+++ b/QuoteGeneration/qcnl/linux/sgx_default_qcnl_intelpcs.conf
@@ -10,7 +10,7 @@
   // To accept insecure HTTPS certificate, set this option to false
   "use_secure_cert": true,
 
-  "collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/"
+  "collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/",
 
   "retry_times": 6,
 


### PR DESCRIPTION
### Summary
This PR adds a missing comma in the config file template `sgx_default_qcnl_intelpcs.conf`.

Closes #457

### Changes
- Added a missing comma in `sgx_default_qcnl_intelpcs.conf`.
- Verified that `QuoteVerificationSample` app now runs correctly.

