### PR TITLE
Fix: add missing ret=-1 on tee_verify_quote failure (untrusted path) in QuoteVerificationSample

### DIFF
--- a/SampleCode/QuoteVerificationSample/App/App.cpp
+++ b/SampleCode/QuoteVerificationSample/App/App.cpp
@@ -409,6 +409,7 @@ int ecdsa_quote_verification(vector<uint8_t> quote, bool use_qve)
         else
         {
             log("Error: App: tee_verify_quote failed: 0x%04x", dcap_ret);
+            ret = -1;
             goto cleanup;
         }
 


### PR DESCRIPTION
In the sample untrusted quote verification path of `ecdsa_quote_verification()`,
when `tee_verify_quote()` fails, the function jumps to cleanup without setting
`ret = -1`. This may result in returning 0 (success) even though the
verification failed.

This patch aligns the untrusted path with the trusted path, which correctly
sets `ret = -1` on failure, ensuring consistent and safe error handling.

No functional impact on successful flows. 
Verified build on Ubuntu 24.04 with SGX SDK 2.26 and DCAP 1.23.