### PR TITLE
pccs: only pass ApiKey if it is set

### DIFF
--- a/QuoteGeneration/pccs/pcs_client/pcs_client.js
+++ b/QuoteGeneration/pccs/pcs_client/pcs_client.js
@@ -66,7 +66,9 @@ async function do_request(url, options) {
       if (!options.headers) {
         options.headers = {};
       }
-      options.headers['Ocp-Apim-Subscription-Key'] = Config.get('ApiKey');
+      if (Config.get('ApiKey') != "") {
+        options.headers['Ocp-Apim-Subscription-Key'] = Config.get('ApiKey');
+      }
     }
 
     // global opitons ( proxy, timeout, etc)
@@ -128,8 +130,11 @@ export async function getCerts(enc_ppid, pceid) {
       pceid: pceid,
     },
     method: 'GET',
-    headers: { 'Ocp-Apim-Subscription-Key': Config.get('ApiKey') },
+    headers: {}
   };
+  if (Config.get('ApiKey') != "") {
+    options.headers['Ocp-Apim-Subscription-Key'] = Config.get('ApiKey');
+  }
 
   return do_request(Config.get('uri') + 'pckcerts', options);
 }
@@ -142,10 +147,13 @@ export async function getCertsWithManifest(platform_manifest, pceid) {
     },
     method: 'POST',
     headers: {
-      'Ocp-Apim-Subscription-Key': Config.get('ApiKey'),
       'Content-Type': 'application/json',
     },
   };
+
+  if (Config.get('ApiKey') != "") {
+    options.headers['Ocp-Apim-Subscription-Key'] = Config.get('ApiKey');
+  }
 
   return do_request(Config.get('uri') + 'pckcerts', options);
 }


### PR DESCRIPTION
Some endpoints on the api.trustedservices.intel.com site do not require an API token. The pcs_client code, however, will always set the Ocp-Apim-Subscription-Key HTTP header, even if it is the empty string. The server will reject the empty string as invalid, rather than prcessing it as an non-authenticated request.

This leads to PCCS being unable to fetch PCK certs in an out of the box config unless the admin sets the API token, which should not be required for "LAZY" caching.