### PR TITLE
Delete broken checks for GCC version that break -fstack-protector-strong

### DIFF
--- a/QuoteVerification/dcap_tvl/Makefile.standalone
+++ b/QuoteVerification/dcap_tvl/Makefile.standalone
@@ -45,12 +45,7 @@ COMMON_LDFLAGS := -Wl,-z,relro,-z,now,-z,noexecstack
 ifneq ($(DEBUG), 1)
     COMMON_FLAGS += -ffunction-sections -fdata-sections
 endif
-CC_BELOW_4_9 := $(shell expr "`$(CC) -dumpversion`" \< "4.9")
-ifeq ($(CC_BELOW_4_9), 1)
-    COMMON_FLAGS += -fstack-protector
-else
-    COMMON_FLAGS += -fstack-protector-strong
-endif
+COMMON_FLAGS += -fstack-protector-strong
 
 ENCLAVE_CFLAGS   = -ffreestanding -nostdinc -fvisibility=hidden -fpie -fno-strict-overflow -fno-delete-null-pointer-checks
 ENCLAVE_CXXFLAGS = $(ENCLAVE_CFLAGS) -nostdinc++

--- a/SampleCode/QuoteAppraisalSample/QAEAppraisal/Makefile
+++ b/SampleCode/QuoteAppraisalSample/QAEAppraisal/Makefile
@@ -87,13 +87,7 @@ Crypto_Library_Name := sgx_tcrypto
 Enclave_Cpp_Files := Enclave/Enclave.cpp
 Enclave_Include_Paths := -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc 
 
-Enclave_C_Flags := $(Enclave_Include_Paths) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections $(MITIGATION_CFLAGS)
-CC_BELOW_4_9 := $(shell expr "`$(CC) -dumpversion`" \< "4.9")
-ifeq ($(CC_BELOW_4_9), 1)
-    Enclave_C_Flags += -fstack-protector
-else
-    Enclave_C_Flags += -fstack-protector-strong
-endif
+Enclave_C_Flags := $(Enclave_Include_Paths) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections $(MITIGATION_CFLAGS) -fstack-protector-strong
 
 Enclave_Cpp_Flags := $(Enclave_C_Flags) -std=c++11 -nostdinc++
 

--- a/SampleCode/QuoteGenerationSample/Makefile
+++ b/SampleCode/QuoteGenerationSample/Makefile
@@ -108,12 +108,7 @@ Crypto_Library_Name := sgx_tcrypto
 Enclave_Cpp_Files := Enclave/Enclave.cpp
 Enclave_Include_Paths := -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/libcxx
 
-CC_BELOW_4_9 := $(shell expr "`$(CC) -dumpversion`" \< "4.9")
-ifeq ($(CC_BELOW_4_9), 1)
-        Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections -fstack-protector
-else
-        Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections -fstack-protector-strong
-endif
+Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections
 Enclave_C_Flags += $(Enclave_Include_Paths)
 Enclave_Cpp_Flags := $(Enclave_C_Flags) -std=c++11 -nostdinc++
 

--- a/SampleCode/QuoteVerificationSample/Makefile
+++ b/SampleCode/QuoteVerificationSample/Makefile
@@ -105,13 +105,7 @@ DCAP_DIR  ?= ../../
 Enclave_Cpp_Files := Enclave/Enclave.cpp
 Enclave_Include_Paths := -IEnclave -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/libcxx
 
-Enclave_C_Flags := $(Enclave_Include_Paths) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections
-CC_BELOW_4_9 := $(shell expr "`$(CC) -dumpversion`" \< "4.9")
-ifeq ($(CC_BELOW_4_9), 1)
-	Enclave_C_Flags += -fstack-protector
-else
-	Enclave_C_Flags += -fstack-protector-strong
-endif
+Enclave_C_Flags := $(Enclave_Include_Paths) -nostdinc -fvisibility=hidden -fpie -ffunction-sections -fdata-sections -fstack-protector-strong
 
 Enclave_Cpp_Flags := $(Enclave_C_Flags) -nostdinc++
 

--- a/ae/qae/Makefile
+++ b/ae/qae/Makefile
@@ -54,12 +54,7 @@ Enclave_Include_Paths := -I./ -I$(WARM_Top_Path)/core/iwasm/include \
                          -I$(DCAP_QV_DIR)/appraisal/common \
                          -I$(DCAP_QG_DIR)/common/inc/internal
 
-CC_BELOW_4_9 := $(shell expr "`$(CC) -dumpversion`" \< "4.9")
-ifeq ($(CC_BELOW_4_9), 1)
-	Enclave_Common_Flags := -fstack-protector
-else
-	Enclave_Common_Flags := -fstack-protector-strong
-endif
+Enclave_Common_Flags := -fstack-protector-strong
 Enclave_Common_Flags += -ffreestanding -fvisibility=hidden -fpie -ffunction-sections -fdata-sections $(Enclave_Include_Paths)
 Enclave_Common_Flags += -DPICOJSON_USE_LOCALE=0 -DBUILD_QAE -DSGX_JWT
 


### PR DESCRIPTION
The expr comparison is performing a string comparison and is thus broken for any GCC version >= 10, preventing use of -fstack-protector-strong

Since GCC 4.9 was released over 9 years ago (Aug 2016), it is thought reasonable to just drop the conditional check and assume -fstack-protector-strong is always available for GCC.
