### PR TITLE
pccsadmin: ignore errors trying to clear the keyring

### DIFF
--- a/tools/PccsAdminTool/lib/intelsgx/pcs.py
+++ b/tools/PccsAdminTool/lib/intelsgx/pcs.py
@@ -343,7 +343,13 @@ class PCS:
         if response.status_code != 200:
             print(str(response.content, 'utf-8'))
             if response.status_code == 401:
-                Credentials().set_pcs_api_key('')   #reset ApiKey
+                try:
+                    Credentials().set_pcs_api_key('')   #reset ApiKey
+                except:
+                    # If keyring is unavailable, we don't want to trigger
+                    # traceback, as the user may have declined to save
+                    # the key in the keyring earlier
+                    pass
             return None
 
         # Verify expected headers
@@ -418,7 +424,13 @@ class PCS:
         if response.status_code != 200:
             print(str(response.content, 'utf-8'))
             if response.status_code == 401:
-                Credentials().set_pcs_api_key('')   #reset ApiKey
+                try:
+                    Credentials().set_pcs_api_key('')   #reset ApiKey
+                except:
+                    # If keyring is unavailable, we don't want to trigger
+                    # traceback, as the user may have declined to save
+                    # the key in the keyring earlier
+                    pass
             return None
 
         # Verify expected headers


### PR DESCRIPTION
On authentication errors with PCS, an attempt is made to clear the keyring. This may fail if the user's login environment has no keyring configured. The user would have declined to store the key when first prompted, so there would be nothing to clear either in this case.