### PR TITLE
Fix broken pccsadmin command with latest pyOpenSSL and use more pycryptography

### DIFF
--- a/tools/PccsAdminTool/lib/intelsgx/pcs.py
+++ b/tools/PccsAdminTool/lib/intelsgx/pcs.py
@@ -24,7 +24,14 @@ except ImportError:
     verification = None
 
 if verification is None:
-    from OpenSSL import crypto
+    try:
+        from OpenSSL import crypto
+    except ModuleNotFoundError:
+        # Fallback to spawning 'openssl' binary if
+        # pyopenssl is not available
+        crypto = None
+        import tempfile
+        import subprocess
 
 from pypac import PACSession
 from platform import system
@@ -165,7 +172,7 @@ class PCS:
                     # Printing or logging the error details
                     print(e)
                     return False
-        else:
+        elif crypto is not None:
             store= self.init_cert_store(pychain)
 
             for pycert in pycerts:
@@ -177,6 +184,23 @@ class PCS:
                     # Printing or logging the error details
                     print(e)
                     return False
+        else:
+            with tempfile.NamedTemporaryFile("wb") as chainfile:
+                for cert in pychain:
+                    chainfile.write(cert.public_bytes(serialization.Encoding.PEM))
+                chainfile.flush()
+
+                for cert in pycerts:
+                    with tempfile.NamedTemporaryFile("wb") as certfile:
+                        certfile.write(cert.public_bytes(serialization.Encoding.PEM))
+                        certfile.flush()
+
+                        try:
+                            subprocess.check_call(["openssl", "verify",
+                                                   "-CAfile", chainfile.name, certfile.name],
+                                                  stdout=subprocess.DEVNULL)
+                        except subprocess.CalledProcessError as e:
+                            return False
 
         return True
 


### PR DESCRIPTION
The pyOpenSSL release 24.3.0 has deleted all the CRL API functionality from its codebase. Their recommendatino is to use the equivalent APIs from pycryptography.  pccsadmin is already using pycryptography to do the CRL verification, but was using pyOpenSSL to load the CRL and is thus broken on modern distros.

Furthermore pyOpenSSL docs indicate that they're considering  deprecating the entire 'crypto' module, again with the recommendation to use pycryptography instead.

This set of patches does the following

 * fix the immediate regression with pyOpenSSL  by using pycryptography to load the CRL
 * make more use of pycryptography for loading certificates only converting to pyOpenSSL objects for cert verification.
 * add an alternative cert verification code path based purely on pycryptography that is used if pycryptography >= 45.0.0 is available
 * add a fallback to 'openssl' command line tool when pycryptography is too old, but pyOpenSSL is not available - this is the case in RHEL9/RHEL10.
 