### PR TITLE
Fix compatibility with QGS for boost 1.87 and 1.89 API changes

### DIFF
--- a/QuoteGeneration/quote_wrapper/qgs/Makefile
+++ b/QuoteGeneration/quote_wrapper/qgs/Makefile
@@ -16,8 +16,8 @@ QGS_INC = -I$(SGX_SDK)/include \
 		  -I$(TOP_DIR)/qpl/inc \
 		  -I$(TOP_DIR)/quote_wrapper/tdx_quote/inc \
 		  -I$(TOP_DIR)/quote_wrapper/qgs_msg_lib/inc
-QGS_CFLAGS = -g -MMD -Werror $(CFLAGS) $(QGS_INC)
-QGS_CXXFLAGS = -g -MMD -Werror $(CXXFLAGS) $(QGS_INC)
+QGS_CFLAGS = -g -MMD -Werror -Wno-deprecated-declarations $(CFLAGS) $(QGS_INC)
+QGS_CXXFLAGS = -g -MMD -Werror -Wno-deprecated-declarations $(CXXFLAGS) $(QGS_INC)
 ifeq ($(CC_NO_LESS_THAN_8), 1)
     QGS_CFLAGS += -fcf-protection=none
     QGS_CXXFLAGS += -fcf-protection=none

--- a/QuoteGeneration/quote_wrapper/qgs/Makefile
+++ b/QuoteGeneration/quote_wrapper/qgs/Makefile
@@ -16,8 +16,8 @@ QGS_INC = -I$(SGX_SDK)/include \
 		  -I$(TOP_DIR)/qpl/inc \
 		  -I$(TOP_DIR)/quote_wrapper/tdx_quote/inc \
 		  -I$(TOP_DIR)/quote_wrapper/qgs_msg_lib/inc
-QGS_CFLAGS = -g -MMD -Werror -Wno-deprecated-declarations $(CFLAGS) $(QGS_INC)
-QGS_CXXFLAGS = -g -MMD -Werror -Wno-deprecated-declarations $(CXXFLAGS) $(QGS_INC)
+QGS_CFLAGS = -g -MMD -Werror -Wno-deprecated-declarations -DBOOST_BIND_GLOBAL_PLACEHOLDERS $(CFLAGS) $(QGS_INC)
+QGS_CXXFLAGS = -g -MMD -Werror -Wno-deprecated-declarations -DBOOST_BIND_GLOBAL_PLACEHOLDERS $(CXXFLAGS) $(QGS_INC)
 ifeq ($(CC_NO_LESS_THAN_8), 1)
     QGS_CFLAGS += -fcf-protection=none
     QGS_CXXFLAGS += -fcf-protection=none

--- a/QuoteGeneration/quote_wrapper/qgs/qgs_server.h
+++ b/QuoteGeneration/quote_wrapper/qgs/qgs_server.h
@@ -36,6 +36,11 @@
 #include <boost/asio.hpp>
 #include <boost/scoped_ptr.hpp>
 
+#if BOOST_VERSION >= 108700
+// Asio no longer defines the deprecated io_service alias.
+namespace boost { namespace asio { using io_service = io_context; } }
+#endif
+
 namespace intel { namespace sgx { namespace dcap { namespace qgs {
 
     namespace asio = boost::asio;

--- a/QuoteGeneration/quote_wrapper/qgs/qgs_server.h
+++ b/QuoteGeneration/quote_wrapper/qgs/qgs_server.h
@@ -34,6 +34,7 @@
 
 #include <stdint.h>
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/scoped_ptr.hpp>
 
 #if BOOST_VERSION >= 108700


### PR DESCRIPTION
In boost 1.87 the (long deprecated) `asio::io_service` type was dropped. To fix this, re-add the compat typedef in qgs code

In boost 1.87 the asio::deadline_timer type was deprecated. To fix this add an explicit #include of the deadline_timer header.

This should retain compat with both old and new Boost versions

