### PR TITLE
pcsclient: only import 'pypac' module on Windows

### DIFF
--- a/tools/PcsClientTool/lib/intelsgx/pcs.py
+++ b/tools/PcsClientTool/lib/intelsgx/pcs.py
@@ -31,8 +31,9 @@ if verification is None:
         import tempfile
         import subprocess
 
-from pypac import PACSession
 from platform import system
+if system() == 'Windows':
+    from pypac import PACSession
 from lib.intelsgx.credential import Credentials
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry


### PR DESCRIPTION
The PACSession object is only used in a code path that runs on Windows, so don't try to import this on Linux, to avoid the redundant dependency.

Previously submitted as #429, but pccsadmin was removed from this repo, and so this resubmission targets pcsclient
