### PR TITLE
pcsclient: remove leftover debugging 'print(args)' statement

### DIFF
--- a/tools/PcsClientTool/pcsclient.py
+++ b/tools/PcsClientTool/pcsclient.py
@@ -63,8 +63,6 @@ def main():
         parser.print_help()
         parser.exit()
 
-    print(args)
-
     args.func(args)
 
 class Utils:


### PR DESCRIPTION
Dumping the python "Namespace" object to stdout after parsing argv serves no end-user purpose:

```
  $ pcsclient.py cache
  Namespace(command='cache', url=None, input_file=None, output_dir=None, sub_dir=False, expire=None, tcb_update_type=None, func=<function pcs_cache at 0x7ff9102ea770>)
  Please note: A prompt may appear asking for your keyring password to access stored credentials.
  Please input ApiKey for Intel PCS:
```

Remove what is presumably a leftover debugging statement:

```
  $ pcsclient.py cache
  Please note: A prompt may appear asking for your keyring password to access stored credentials.
  Please input ApiKey for Intel PCS:
```