### PR TITLE
pcsclient: improvements to keyring handling

### DIFF
--- a/tools/PcsClientTool/lib/intelsgx/credential.py
+++ b/tools/PcsClientTool/lib/intelsgx/credential.py
@@ -1,4 +1,7 @@
-import keyring
+try:
+    import keyring
+except:
+    keyring = None
 import getpass
 
 class Credentials:
@@ -7,11 +10,12 @@ class Credentials:
 
     def get_pcs_api_key(self):
         pcs_api_key = ""
-        try:
-            print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
-            pcs_api_key = keyring.get_password(self.APPNAME, self.KEY_PCS_APIKEY)
-        except keyring.errors.KeyringError as ke:
-            pcs_api_key = ""
+        if keyring is not None:
+            try:
+                print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
+                pcs_api_key = keyring.get_password(self.APPNAME, self.KEY_PCS_APIKEY)
+            except keyring.errors.KeyringError as ke:
+                pcs_api_key = ""
         
         while pcs_api_key is None or pcs_api_key == '':
             pcs_api_key = getpass.getpass(prompt="Please input ApiKey for Intel PCS:")
@@ -24,10 +28,11 @@ class Credentials:
         return pcs_api_key
 
     def set_pcs_api_key(self, apikey):
-        try:
-            print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
-            keyring.set_password(self.APPNAME, self.KEY_PCS_APIKEY, apikey)
-        except keyring.errors.PasswordSetError as ke:
-            print("Failed to store PCS API key.")
-            return False
+        if keyring is not None:
+            try:
+                print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
+                keyring.set_password(self.APPNAME, self.KEY_PCS_APIKEY, apikey)
+            except keyring.errors.PasswordSetError as ke:
+                print("Failed to store PCS API key.")
+                return False
         return True

--- a/tools/PcsClientTool/lib/intelsgx/pcs.py
+++ b/tools/PcsClientTool/lib/intelsgx/pcs.py
@@ -343,7 +343,13 @@ class PCS:
         if response.status_code != 200:
             print(str(response.content, 'utf-8'))
             if response.status_code == 401:
-                Credentials().set_pcs_api_key('')   #reset ApiKey
+                try:
+                    Credentials().set_pcs_api_key('')   #reset ApiKey
+                except:
+                    # If keyring is unavailable, we don't want to trigger
+                    # traceback, as the user may have declined to save
+                    # the key in the keyring earlier
+                    pass
             return None
 
         # Verify expected headers
@@ -418,7 +424,13 @@ class PCS:
         if response.status_code != 200:
             print(str(response.content, 'utf-8'))
             if response.status_code == 401:
-                Credentials().set_pcs_api_key('')   #reset ApiKey
+                try:
+                    Credentials().set_pcs_api_key('')   #reset ApiKey
+                except:
+                    # If keyring is unavailable, we don't want to trigger
+                    # traceback, as the user may have declined to save
+                    # the key in the keyring earlier
+                    pass
             return None
 
         # Verify expected headers


### PR DESCRIPTION
Not all distros (in my case RHEL-9/10) have the python3-keyring module available.

Use of the keyring is not a critical feature of pccsadmin, just a "nice to have". The user already has the option to decline to store a password in the keyring, so it is conceptually reasonable to support running without the keyring module present at all.

Furthermore, when seeing an authentication failure, a failure to clear the keyring should be treated as non-fatal since the user may have declined to store in the keyring to begin with.

The equivalent patches were previously submitted as #480 and as #476 for pccsadmin. This new PR for pcsclient combines the two, since they were complementary parts of the same problem.

The changes are still applicable to the new separated pccsadmin tool, so have also been submitted to https://github.com/intel/confidential-computing.tee.dcap.pccs/pull/39