### PR TITLE
pcsclient: make platform list optional for fetch subcommand

### DIFF
--- a/tools/PcsClientTool/README.txt
+++ b/tools/PcsClientTool/README.txt
@@ -14,13 +14,15 @@ positional arguments:
 optional arguments:
   -h, --help       show this help message and exit
 
-1. Fetch platform collateral data from Intel PCS based on the registration data
+1. Fetch platform collateral data from Intel PCS
   ./pcsclient.py fetch [-h] [-u URL] [-i INPUT_FILE] [-o OUTPUT_FILE]
 
   optional arguments:
           -h, --help            show this help message and exit
           -i INPUT_FILE, --input_file INPUT_FILE
-                                The input file name for platform list; default: platform_list.json
+                                The input file name for platform list. When omitted, PCK certificate
+                                fetching is skipped; CRLs, TCB infos, and enclave identities are
+                                still retrieved.
           -o OUTPUT_FILE, --output_file OUTPUT_FILE
                                 The output file name for platform collaterals; default: platform_collaterals.json
           -u URL, --url URL     The URL of the Intel PCS service; default: https://api.trustedservices.intel.com/sgx/certification/v4/

--- a/tools/PcsClientTool/pcsclient.py
+++ b/tools/PcsClientTool/pcsclient.py
@@ -149,13 +149,14 @@ class CollateralFetcher:
         self.args = args
         self.url = args.url or PCS_SERVICE_URL
         self.ApiVersion = Utils.get_api_version_from_url(self.url)
+        self.has_platform_list = bool(args.input_file)
         self.input_file = args.input_file or 'platform_list.json'
         self.output_file = args.output_file or 'platform_collaterals.json'
         self.fmspc_platform = args.platform or 'all'
         self.tcb_update_type = args.tcb_update_type or 'standard'
         self.crl_only = bool(args.crl and not args.input_file)
         self.apikey = ""
-        if not self.crl_only:
+        if not self.crl_only and self.has_platform_list:
             self.apikey = self.credentials.get_pcs_api_key()
         self.pcsclient = PCS(self.url, self.ApiVersion, self.apikey)
         self.sgxext = SgxPckCertificateExtensions()
@@ -171,9 +172,10 @@ class CollateralFetcher:
             if self.crl_only:
                 self._write_output_json()
                 return
-            self._load_platform_list()
-            if not self._fetch_pck_certs():
-                return
+            if self.has_platform_list:
+                self._load_platform_list()
+                if not self._fetch_pck_certs():
+                    return
             if not self._fetch_tcbinfos():
                 return
             if not self._fetch_identity('qe'):
@@ -214,6 +216,9 @@ class CollateralFetcher:
             print("Failed to get processor PCK CRL.")
             return False
         self.output_json["collaterals"]["pckcacrl"]["processorCrl"] = processorCrl[0]
+        if not self.has_platform_list:
+            pckchain = self.output_json["collaterals"]["certificates"][PCS.HDR_PCK_Certificate_Issuer_Chain]
+            pckchain['PROCESSOR'] = processorCrl[1]
 
         if self.ApiVersion >= 3:
             platformCrl = self.pcsclient.get_pck_crl('platform', 'ascii')
@@ -221,6 +226,8 @@ class CollateralFetcher:
                 print("Failed to get platform PCK CRL.")
                 return False
             self.output_json["collaterals"]["pckcacrl"]["platformCrl"] = platformCrl[0]
+            if not self.has_platform_list:
+                pckchain['PLATFORM'] = platformCrl[1]
 
         # output.collaterals.rootcacrl
         spos = processorCrl[1].rfind('-----BEGIN%20CERTIFICATE-----')


### PR DESCRIPTION
There are cases where platform registration information is not available but quote verification collateral needs to be pulled from PCS.

pcsclient fetch already pulls *all* verification data (not just the ones specified by the registered platforms) so the necessary functionality is already there.

However, fetch does not work without input files (i.e. the list of registered platforms). Relax this requirement and make it possible to pull platform collateral without PCK certificates to have verifcation collateral available.

Pulling verification collateral does not use the api-key so that can also be skipped when the platform list is not provided.