### PR TITLE
pcsclient: serialize qeidentity and tdqeidentity as JSON

### DIFF
--- a/tools/PcsClientTool/pcsclient.py
+++ b/tools/PcsClientTool/pcsclient.py
@@ -362,7 +362,7 @@ class CollateralFetcher:
                     return False
             else:
                 key_suffix = '_early' if update == 'early' else ''
-                self.output_json["collaterals"][f"{identity_type}identity{key_suffix}"] = identity[0]
+                self.output_json["collaterals"][f"{identity_type}identity{key_suffix}"] = json.loads(identity[0])
                 if identity_type == 'qe':
                     self.output_json["collaterals"]["certificates"][PCS.HDR_Enclave_Identity_Issuer_Chain] = identity[1]
         return True


### PR DESCRIPTION
_fetch_identity() sets the raw PCS response body (a JSON string) directly to the output dict which gets serialized as a string in the final JSON output file with json.dumps().

The result is that the output file cannot be deserialized as Enclave Identity V2 JSON.

Similar to how TCB Info is already handled, parse Enclave Identity response before storing the PCS response into the output_json dict. This makes (td)qeidentity to look proper JSON.

Fixes: #497 