### PR TITLE
Wrong type of arguments to formatting function

### DIFF
--- a/tools/SGXPlatformRegistration/src/network/src/MPSynchronicSender.cpp
+++ b/tools/SGXPlatformRegistration/src/network/src/MPSynchronicSender.cpp
@@ -36,6 +36,7 @@
  */
 #include <curl/curl.h>
 #include <cstring>
+#include <climits>
 #include <unistd.h>
 
 #include "network_logger.h"
@@ -80,7 +81,8 @@ static size_t responseHeaderCallBack(char* b, size_t size, size_t nitems, void *
     string strline = string(b, numbytes);
     string *errorCodeStr = (string*)userdata;
     if (numbytes > 2) {
-        network_log_message_aux(mpNetworkLoglevel, MP_REG_LOG_LEVEL_DEBUG, "%.*s", numbytes, b);
+        int logLen = (numbytes > static_cast<size_t>(INT_MAX)) ? INT_MAX : static_cast<int>(numbytes);
+        network_log_message_aux(mpNetworkLoglevel, MP_REG_LOG_LEVEL_DEBUG, "%.*s", logLen, b);
     }
 
     size_t found = strline.find(ERROR_CODE_STR_RESPONSE_HEADER);


### PR DESCRIPTION
Potential fix for [https://github.com/intel/confidential-computing.tee.dcap/security/code-scanning/48](https://github.com/intel/confidential-computing.tee.dcap/security/code-scanning/48)

Use a correctly typed precision argument for `"%.*s"` by converting `numbytes` (`size_t`) to `int` only after bounding it to `INT_MAX`. This keeps behavior the same (log up to full header line) while removing undefined behavior from varargs mismatch.

**Best fix in this file/region:**
- Edit `tools/SGXPlatformRegistration/src/network/src/MPSynchronicSender.cpp` in `responseHeaderCallBack` around line 83.
- Add `<climits>` include (for `INT_MAX`).
- Replace the direct use of `numbytes` in the log call with a bounded `int` local variable, e.g.:
  - `int logLen = (numbytes > static_cast<size_t>(INT_MAX)) ? INT_MAX : static_cast<int>(numbytes);`
  - then call `network_log_message_aux(..., "%.*s", logLen, b);`

No functional behavior change beyond making the formatting call type-safe in all builds.