### PR TITLE
gitignore: fix path for qgs binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ SHA256SUM_prebuilt_dcap_*.cfg
 
 # Built executables
 tools/PCKRetrievalTool/PCKIDRetrievalTool
-QuoteGeneration/quote_wrapper/qgs
-QuoteGeneration/quote_wrapper/test_client
+QuoteGeneration/quote_wrapper/qgs/qgs
+QuoteGeneration/quote_wrapper/qgs/test_client
 QuoteVerification/appraisal/tee_appraisal_tool/tee_appraisal_tool
 
 #CMake outputs


### PR DESCRIPTION
The '/qgs/' path component was missing for the two binaries, resulting in the entire qgs source directory being ignored.