### PR TITLE
servtd_attest: drop obsolete pce_wrapper/inc directory

### DIFF
--- a/QuoteGeneration/quote_wrapper/servtd_attest/linux/Makefile
+++ b/QuoteGeneration/quote_wrapper/servtd_attest/linux/Makefile
@@ -125,11 +125,11 @@ $(ServTd_Attest_Lib_Name): $(CPP_Objects) submodule
 	$(CXX) $(CPP_Objects) $(SERVTD_ATTEST_BUILD_DIR)/*.o $(QVL_LIB_FILES:.cpp=.o) $(QVL_PARSER_FILES:.cpp=.o) $(Servtd_Attest_LDFLAGS) -shared -o $@
 
 test_app_static: $(ServTd_Attest_Static_Lib_Name)
-	$(CXX) -fpie -pie -I../inc -I../../common/inc -I$(SERVTD_ATTEST_LINUX_TRUNK_ROOT_PATH)/common/inc -I$(DCAP_QG_DIR)/pce_wrapper/inc -I$(QV_QVE_INC_DIR) ../test_servtd_attest.cpp -L. -Wl,-Bstatic -lservtd_attest -Wl,-Bdynamic \
+	$(CXX) -fpie -pie -I../inc -I../../common/inc -I$(SERVTD_ATTEST_LINUX_TRUNK_ROOT_PATH)/common/inc -I$(QV_QVE_INC_DIR) ../test_servtd_attest.cpp -L. -Wl,-Bstatic -lservtd_attest -Wl,-Bdynamic \
 	-Wl,--defsym,__ImageBase=0 -Wl,--gc-sections -g -O0 -ggdb -o $@
 
 test_app: $(ServTd_Attest_Lib_Name)
-	$(CXX) -fpie -pie -I../inc -I../../common/inc -I$(SERVTD_ATTEST_LINUX_TRUNK_ROOT_PATH)/common/inc -I$(DCAP_QG_DIR)/pce_wrapper/inc -I$(QV_QVE_INC_DIR) ../test_servtd_attest.cpp -L. -lservtd_attest -Wl,-rpath,'$$ORIGIN' -g -O0 -ggdb -fpermissive -o $@
+	$(CXX) -fpie -pie -I../inc -I../../common/inc -I$(SERVTD_ATTEST_LINUX_TRUNK_ROOT_PATH)/common/inc -I$(QV_QVE_INC_DIR) ../test_servtd_attest.cpp -L. -lservtd_attest -Wl,-rpath,'$$ORIGIN' -g -O0 -ggdb -fpermissive -o $@
 
 test_clean:
 	@rm -rf $(ServTd_Attest_Lib_Name) *.map


### PR DESCRIPTION
The -I$(DCAP_QG_DIR)/pce_wrapper/inc flag points to a directory that no longer exists in DCAP 1.26, since the include file moved into the SGX SDK with:

  commit a2e73fcf6d7a50ffed3da591bb0f92bfc15c5370
  Author: Krzysztof Wiśniewski <krzysztof1.wisniewski@intel.com>
  Date:   Tue Mar 24 10:34:36 2026 +0100

    Removes SGX SDK–related headers/TVL from DCAP (moved to SGX repo)

The new location is already referenced in an earlier -I flag, so the old directory can simply be dropped.